### PR TITLE
OCR the artwork structured data publishes: right flyer, and the end time off it

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1131,10 +1131,14 @@ class AiWebParser {
                 // featured event — fall through to segment extraction for full coverage.
                 && (pageClassification !== 'multi-event-page' || structuredEvents.length >= 2);
             if (useStructuredEvents) {
+                // "skipping OCR" was true when this route read no images at
+                // all; the events' own artwork is OCR'd below, so the line
+                // now names what is actually skipped (the ocr-all sweep and
+                // the AI extraction passes).
                 if (structuredSource === 'json-api') {
-                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON API structured data — skipping OCR and AI extraction`);
+                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON API structured data — skipping the OCR sweep and AI extraction (event artwork is still read)`);
                 } else {
-                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON-LD structured data — skipping OCR and AI extraction`);
+                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON-LD structured data — skipping the OCR sweep and AI extraction (event artwork is still read)`);
                 }
                 // Structured-data events skip normalizeAiEvent, so the title
                 // cleanups that live there have to be applied here as well —
@@ -1194,6 +1198,12 @@ class AiWebParser {
                 // published a 1x1 spacer can still adopt the page's real
                 // artwork instead of keeping the pixel.
                 structuredEvents.forEach(event => this.rejectPlaceholderImageValues(event));
+                // Read the structured nodes' OWN artwork before anything
+                // judges it. Runs FIRST so the furniture rejection below and
+                // every later image decision argue from what the flyer says
+                // instead of from the shape of its URL.
+                const structuredArtworkOcrCount = await this.vetStructuredEventArtwork(
+                    structuredEvents, parserConfig, httpAdapter);
                 // …and neither is a logo the vision pass already read as page
                 // furniture. Same position and same reasoning as the
                 // placeholder rejection above: reject BEFORE the og:image fill,
@@ -1264,7 +1274,11 @@ class AiWebParser {
                     additionalLinks: additionalLinks,
                     discoveredSegments: null,
                     ocrResults: [],
-                    extractionSummary: { source: structuredSource, aiPasses: this.aiPromptHistory.length, ocrImages: 0 },
+                    // ocrImages is no longer structurally 0 on this route: the
+                    // structured nodes' artwork is read here, and the summary
+                    // has to say so or the run reports OCR it actually did as
+                    // OCR it skipped.
+                    extractionSummary: { source: structuredSource, aiPasses: this.aiPromptHistory.length, ocrImages: structuredArtworkOcrCount },
                     source: this.config.source,
                     url: sourceUrl
                 };
@@ -17753,6 +17767,48 @@ TEXT:
             const verdict = this.getOcrImageVerdict(upgraded);
             console.log(`🤖 AI Web: OCR-vetted page og:image ${upgraded} before adoption — ${verdict ? verdict.classification : 'no classification'}`);
         }
+    }
+
+    // Read the artwork the structured data itself published. The JSON-LD /
+    // JSON-API route returns before the ocr-all pass, so these images — the
+    // ones that actually reach the calendar — were the only flyers in the
+    // system nobody ever looked at. Everything downstream that reasons about
+    // an image asks the vision pass what it SAYS: the furniture rejection
+    // right after this call, the flyer-vs-page time conflict flag, and
+    // shared-core's merge-time title-evidence rung, which decides which of
+    // two flyers belongs to the event being written. Without a verdict they
+    // all fail open on "unknown" — which is how Club Chub's renamed night
+    // kept its old "Wig Out" flyer while the page served the real MEAT
+    // MARKET poster (run 20260828-163440: sickening.events hosts event art
+    // under /saas/logos/, so the URL-shape rung read the new flyer as site
+    // chrome). One bounded call per DISTINCT image, then the OCR cache
+    // answers forever; OCR is local-model work and the standing doctrine is
+    // to spend it.
+    async vetStructuredEventArtwork(events, parserConfig, httpAdapter) {
+        if (!Array.isArray(events) || events.length === 0) return 0;
+        const ocrConfig = this.getOcrConfig(parserConfig);
+        if (!ocrConfig || !ocrConfig.enabled) return 0;
+        const seenImageKeys = new Set();
+        let vettedCount = 0;
+        for (const event of events) {
+            const image = event && typeof event.image === 'string' ? event.image.trim() : '';
+            if (!image || !/^https?:\/\//i.test(image)) continue;
+            if (this.isLikelyUninterestingImageUrl(image)) continue;
+            const imageKey = this.canonicalizeImageUrlForComparison(image) || image;
+            if (seenImageKeys.has(imageKey)) continue;
+            seenImageKeys.add(imageKey);
+            // Already read this run (the og:image vet, or a sibling event
+            // sharing the flyer) — the verdict store is the same seam.
+            if (this.getOcrImageVerdict(image)) continue;
+            const rawResult = await this.getOcrTextForImage(image, ocrConfig, 'structured artwork', httpAdapter).catch(() => null);
+            const normalized = this.normalizeOcrResult(rawResult);
+            if (!normalized) continue;
+            this.recordOcrImageVerdict(image, normalized);
+            vettedCount += 1;
+            const verdict = this.getOcrImageVerdict(image);
+            console.log(`🤖 AI Web: OCR-read structured-data artwork for "${event.title || 'Unknown'}" — ${verdict ? verdict.classification : 'no classification'}: ${image}`);
+        }
+        return vettedCount;
     }
 
     fillImageFromPageMetaArtwork(event, htmlData) {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1269,6 +1269,12 @@ class AiWebParser {
                 // adoption above OCR-vetted it into the verdict registry)
                 // state a different start time than the structured data?
                 this.applyFlyerTimeConflictFlag(keptStructuredEvents);
+                // Gap-fill, not override: an event the page published with no
+                // end time takes one from its own flyer when the flyer's
+                // range starts at the time the page already states. Runs
+                // AFTER the conflict flag so a flyer that disagrees about the
+                // START is already on record as suspect.
+                this.fillEndTimeFromFlyerOcr(keptStructuredEvents);
                 return {
                     events: keptStructuredEvents,
                     additionalLinks: additionalLinks,
@@ -15790,6 +15796,121 @@ TEXT:
         }
     }
 
+    // Fill a MISSING end time from the event's own flyer. Structured data is
+    // routinely start-only (sickening.events publishes no endDate at all),
+    // and an event with no end is not a cosmetic gap: EventKit refuses to
+    // save one outright, so Club Chub's MEAT MARKET could not be written at
+    // all until the merge learned to keep the calendar's stored end
+    // (run 20260828-163440). The flyer had the answer the whole time —
+    // "SUNDAY NOVEMBER 1ST 4 TO 9PM" — and now that this route OCR-reads its
+    // own artwork, it can be read instead of guessed.
+    //
+    // Fail closed at every step, because inventing a duration is worse than
+    // leaving the gap:
+    //   - only ever fills an ABSENT end; a stated end is never touched
+    //   - needs a resolved timezone (a wall-clock reading without one is a
+    //     guess) and a real stated start (local midnight is the date-only
+    //     default, which anchors nothing)
+    //   - the flyer must not name a date this event cannot be on
+    //   - the flyer must state a RANGE whose start is unambiguous and equals
+    //     the page's own start — that agreement is what proves the range
+    //     describes THIS event — and exactly one such range-end may exist
+    //   - the resulting span must be positive and <= 12h (past that, the
+    //     reading is more likely an AM/PM slip than a party)
+    // No notes field is written: this fills the event's own endDate, and the
+    // reasoning lands in the log and on the event's evidence lines.
+    fillEndTimeFromFlyerOcr(events) {
+        if (!Array.isArray(events) || events.length === 0) return 0;
+        if (!this.core || typeof this.core.formatLocalClockTime !== 'function'
+            || typeof this.core.convertWallClockDateToUtc !== 'function'
+            || typeof this.core.getTimezoneOffsetMinutes !== 'function') return 0;
+        let filledCount = 0;
+        for (const event of events) {
+            if (!event || typeof event !== 'object') continue;
+            if (event.endDate || !event.startDate) continue;
+            const timezone = typeof event.timezone === 'string' ? event.timezone.trim() : '';
+            if (!timezone || event._timezoneUnresolved) continue;
+            const imageUrl = typeof event.image === 'string' ? event.image.trim() : '';
+            if (!imageUrl) continue;
+            const verdict = this.getOcrImageVerdict(imageUrl);
+            if (!verdict) continue;
+            // Known page furniture states nothing about this event's hours.
+            // Anything else qualifies — INCLUDING a verdict with no
+            // classification at all, which is not an exotic case: a salvaged
+            // OCR response keeps its text and loses its classification (the
+            // MEAT MARKET poster itself comes back this way, the model having
+            // buried the JSON under a run of newlines). Demanding
+            // 'event-flyer' would refuse the very flyer this exists to read,
+            // and the agreement test below is the real gate: furniture does
+            // not print a time range starting at the event's own start.
+            if (this.nonEventOcrImageClassifications.has(verdict.classification)) continue;
+            const ocrText = typeof verdict.text === 'string' ? verdict.text : '';
+            if (!ocrText.trim()) continue;
+            const localDates = this.getFlyerLocalDateCandidates(event);
+            if (!localDates || flyerOcrContradictsEventDate(ocrText, localDates)) continue;
+
+            const startClock = this.core.formatLocalClockTime(event.startDate, timezone);
+            const startMatch = /^(\d{2}):(\d{2})$/.exec(startClock || '');
+            if (!startMatch || startClock === '00:00') continue;
+            const startMinutes = (parseInt(startMatch[1], 10) * 60) + parseInt(startMatch[2], 10);
+
+            const endMinutesFound = this.readFlyerRangeEndMinutes(ocrText, startMinutes);
+            if (endMinutesFound === null) continue;
+
+            const spanMinutes = ((endMinutesFound - startMinutes) + 1440) % 1440;
+            if (spanMinutes === 0 || spanMinutes > 12 * 60) continue;
+
+            const startOffset = this.core.getTimezoneOffsetMinutes(new Date(event.startDate), timezone);
+            if (!Number.isFinite(startOffset)) continue;
+            // UTC components of this view hold the LOCAL wall clock, which is
+            // the shape convertWallClockDateToUtc reinterprets.
+            const localView = new Date(new Date(event.startDate).getTime() + (startOffset * 60 * 1000));
+            const endWallClock = new Date(Date.UTC(
+                localView.getUTCFullYear(),
+                localView.getUTCMonth(),
+                localView.getUTCDate() + (endMinutesFound <= startMinutes ? 1 : 0),
+                Math.floor(endMinutesFound / 60),
+                endMinutesFound % 60
+            ));
+            const resolvedEnd = this.core.convertWallClockDateToUtc(endWallClock, timezone);
+            if (!resolvedEnd || isNaN(resolvedEnd.getTime())) continue;
+
+            event.endDate = resolvedEnd;
+            filledCount += 1;
+            const pad = (value) => String(value).padStart(2, '0');
+            const endClock = `${pad(Math.floor(endMinutesFound / 60))}:${pad(endMinutesFound % 60)}`;
+            const evidence = `endDate: read ${startClock}–${endClock} off the event's flyer (page published no end time)`;
+            if (Array.isArray(event._evidenceLines)) {
+                event._evidenceLines.push(evidence);
+            } else {
+                event._evidenceLines = [evidence];
+            }
+            console.log(`🕐 AI Web: Filled missing end for "${event.title || 'Unknown'}" from flyer OCR — ${startClock}–${endClock} local (${Math.round(spanMinutes / 60 * 10) / 10}h)`);
+        }
+        return filledCount;
+    }
+
+    // The end of the flyer's stated time range, in minutes-of-day, ONLY when
+    // the range's start is unambiguous and agrees with the page's own start.
+    // That agreement is the whole anti-hallucination gate: a flyer listing
+    // some other night's hours cannot pass it. Returns null unless exactly
+    // one such end exists (a flyer disagreeing with itself decides nothing).
+    readFlyerRangeEndMinutes(ocrText, startMinutes) {
+        const readings = collectFlyerOcrTimeReadings(ocrText);
+        if (readings.length === 0) return null;
+        const endMinutes = new Set();
+        for (let index = 0; index < readings.length; index++) {
+            const reading = readings[index];
+            if (!reading.isRangeStart || !reading.unambiguous) continue;
+            if (reading.minutes !== startMinutes) continue;
+            const rangeEnd = readings
+                .slice(index + 1)
+                .find(candidate => candidate.line === reading.line && candidate.isRangeEnd);
+            if (rangeEnd && rangeEnd.unambiguous) endMinutes.add(rangeEnd.minutes);
+        }
+        return endMinutes.size === 1 ? [...endMinutes][0] : null;
+    }
+
     normalizeAiEvent(aiEvent, parserConfig, htmlData = null, cityConfig = null, promptFields = null) {
         const scrapedLinks = this.extractLinksFromPage(
             htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
@@ -17793,7 +17914,14 @@ TEXT:
         for (const event of events) {
             const image = event && typeof event.image === 'string' ? event.image.trim() : '';
             if (!image || !/^https?:\/\//i.test(image)) continue;
-            if (this.isLikelyUninterestingImageUrl(image)) continue;
+            // NO isLikelyUninterestingImageUrl gate here, unlike the page-meta
+            // vet: that helper is a URL-shape guess, and this image is not a
+            // candidate scraped off the page — the structured data DECLARED it
+            // as this event's artwork. Guessing from the path is the whole bug
+            // being fixed (it calls sickening.events' /saas/logos/ poster
+            // uninteresting), and refusing to read the one image that reaches
+            // the calendar is how the guess became unfalsifiable. Placeholder
+            // pixels are already gone: rejectPlaceholderImageValues runs first.
             const imageKey = this.canonicalizeImageUrlForComparison(image) || image;
             if (seenImageKeys.has(imageKey)) continue;
             seenImageKeys.add(imageKey);
@@ -17803,10 +17931,16 @@ TEXT:
             const rawResult = await this.getOcrTextForImage(image, ocrConfig, 'structured artwork', httpAdapter).catch(() => null);
             const normalized = this.normalizeOcrResult(rawResult);
             if (!normalized) continue;
-            this.recordOcrImageVerdict(image, normalized);
+            // Text-only fallback for a salvaged read: without it the flyer
+            // this call just paid for stays invisible to every consumer.
+            this.recordOcrImageVerdict(image, normalized)
+                || this.recordOcrImageTextEvidence(image, normalized);
             vettedCount += 1;
             const verdict = this.getOcrImageVerdict(image);
-            console.log(`🤖 AI Web: OCR-read structured-data artwork for "${event.title || 'Unknown'}" — ${verdict ? verdict.classification : 'no classification'}: ${image}`);
+            const readAs = verdict
+                ? (verdict.classification || 'unclassified (text recovered)')
+                : 'nothing readable';
+            console.log(`🤖 AI Web: OCR-read structured-data artwork for "${event.title || 'Unknown'}" — ${readAs}: ${image}`);
         }
         return vettedCount;
     }
@@ -18206,6 +18340,38 @@ TEXT:
             // The transcription itself, for the brand-token furniture gate in
             // getNonEventImageOcrReason: a logo whose only readable text is
             // the page's own brand/venue name is still page furniture.
+            text: rawText
+        };
+        let recorded = false;
+        for (const url of [imageUrl, result.imageUrl, result.url, this.normalizeHttpUrlValue(imageUrl)]) {
+            const key = this.canonicalizeImageUrlForComparison(url);
+            if (!key) continue;
+            this.ocrImageVerdictsByUrl.set(key, verdict);
+            recorded = true;
+        }
+        return recorded ? verdict : null;
+    }
+
+    // Record what an image SAYS when the model never said what it IS.
+    // recordOcrImageVerdict refuses a result with no classification — its
+    // contract is a classification verdict — but a salvaged OCR response
+    // (text recovered from a truncated/malformed JSON reply) routinely has
+    // exactly that shape, and its transcription is still real evidence. The
+    // MEAT MARKET poster comes back this way every time: the model buries
+    // the JSON under a run of newlines, the salvage keeps the words, and the
+    // verdict store then held nothing at all for the one flyer that mattered.
+    // Classification is left EMPTY on purpose: every furniture gate asks
+    // whether the classification is in nonEventOcrImageClassifications, and
+    // '' is not, so those gates fail open exactly as they did on a missing
+    // verdict. Only the consumers that want the text see a difference.
+    recordOcrImageTextEvidence(imageUrl, result) {
+        if (!result || typeof result !== 'object') return null;
+        const rawText = String(result.text || '').trim();
+        if (!this.ocrTextHasMeaningfulContent(rawText)) return null;
+        const verdict = {
+            classification: '',
+            hasText: true,
+            hasGlyphNoiseOnly: false,
             text: rawText
         };
         let recorded = false;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7565,7 +7565,7 @@ const REDEYE_SEARCH_PAYLOAD = {
 };
 const REDEYE_SOURCE_URL = 'https://api.redeyetickets.com/api/v2/events/search?venue=red-eye-ny';
 
-test('parseEvents extracts the Red Eye search payload via the JSON-API structured path with zero AI/OCR calls', async () => {
+test('parseEvents extracts the Red Eye search payload via the JSON-API structured path with zero AI calls and no OCR sweep', async () => {
   const parser = createParser();
   let aiCalls = 0;
   let ocrCalls = 0;
@@ -7601,10 +7601,51 @@ test('parseEvents extracts the Red Eye search payload via the JSON-API structure
   assert.equal(event.ticketUrl, '', 'slug never becomes a ticket URL');
 
   assert.equal(aiCalls, 0, 'no extraction AI on the structured path');
-  assert.equal(ocrCalls, 0, 'no OCR on the structured path');
+  assert.equal(ocrCalls, 0, 'the page-wide OCR sweep still never runs here');
+  // No httpAdapter in this call, so the artwork read has nothing to fetch with
+  // — the summary reports the zero honestly rather than by construction.
   assert.deepEqual(result.extractionSummary, { source: 'json-api', aiPasses: 0, ocrImages: 0 });
   assert.ok(logs.includes('🤖 AI Web: JSON API response detected (1 candidate event object(s))'));
-  assert.ok(logs.includes('🤖 AI Web: Extracted 1 event(s) from JSON API structured data — skipping OCR and AI extraction'));
+  assert.ok(logs.includes('🤖 AI Web: Extracted 1 event(s) from JSON API structured data — skipping the OCR sweep and AI extraction (event artwork is still read)'));
+});
+
+// The structured route returns before the ocr-all sweep, which left the ONE
+// image that reaches the calendar unread — so every downstream image judgment
+// (furniture rejection, flyer/page time conflict, and shared-core's merge-time
+// title-evidence rung) failed open on "unknown". Club Chub's renamed night kept
+// its stale "Wig Out" flyer that way: sickening.events serves event artwork
+// under /saas/logos/, and with no OCR the URL-shape rung called the real MEAT
+// MARKET poster site chrome.
+test('structured path OCR-reads the events own artwork so downstream image decisions have evidence', async () => {
+  const parser = createParser();
+  parser.core.callAiGenerate = async () => null;
+  parser.extractOcrFromAllImages = async () => { throw new Error('the OCR sweep must not run on the structured path'); };
+  const ocrRequests = [];
+  parser.getOcrTextForImage = async (imageUrl, ocrConfig, passLabel) => {
+    ocrRequests.push({ imageUrl, passLabel });
+    return { text: 'GOLDILOXX JULY\nRED EYE NY\nDJ JOE MICHAEL', classification: 'event-flyer' };
+  };
+  const cityConfig = { nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] } };
+
+  const result = await parser.parseEvents(
+    { url: REDEYE_SOURCE_URL, html: JSON.stringify(REDEYE_SEARCH_PAYLOAD) },
+    {},
+    cityConfig,
+    'event-page',
+    { fetchImageAsBase64: async () => 'ZmFrZQ==' }
+  );
+
+  assert.equal(result.events.length, 1);
+  assert.equal(ocrRequests.length, 1, 'the event artwork is read exactly once');
+  assert.equal(ocrRequests[0].imageUrl, 'https://redeye-event-flyers.s3.amazonaws.com/img_9849-optimized.jpg');
+  assert.equal(ocrRequests[0].passLabel, 'structured artwork');
+  assert.equal(result.extractionSummary.ocrImages, 1, 'the summary reports the read');
+  assert.equal(result.events[0].image, 'https://redeye-event-flyers.s3.amazonaws.com/img_9849-optimized.jpg',
+    'reading the flyer never costs the event its picture');
+
+  const verdict = parser.getOcrImageVerdict('https://redeye-event-flyers.s3.amazonaws.com/img_9849-optimized.jpg');
+  assert.ok(verdict, 'the verdict is registered where every downstream consumer looks it up');
+  assert.match(String(verdict.text), /GOLDILOXX JULY/);
 });
 
 test('extractEventsFromJsonApiPayload expands a detail-shaped payload into one event per performance', () => {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15624,3 +15624,155 @@ test('JSON-API events never carry the fetch URL as their identity link, whatever
     'https://tockify.com/api/ngevent?calname=thotyssey&tags=rockbar', null);
   assert.equal(events[0].url, '');
 });
+
+// ---------------------------------------------------------------------------
+// Missing end times, filled from the event's own flyer.
+//
+// Structured data is routinely start-only — sickening.events publishes no
+// endDate at all — and an event with no end is not a cosmetic gap: EventKit
+// refuses to save one, which is why Club Chub's MEAT MARKET could not be
+// written at all (run 20260828-163440, "No end date has been set."). The
+// flyer stated the hours the whole time: "SUNDAY NOVEMBER 1ST 4 TO 9PM".
+// The gate is agreement — the flyer's range must START at the time the page
+// already publishes — because inventing a duration is worse than the gap.
+// ---------------------------------------------------------------------------
+
+const MEAT_MARKET_FLYER_IMAGE = 'https://res.cloudinary.com/eventservice/image/upload/saas/logos/image_1786814597049.webp';
+// The vision model's real transcription of that poster, 2026-08-28.
+const MEAT_MARKET_FLYER_OCR = [
+  'CLUB CHUB', 'CANNONBALL WEEKEND', 'MEAT', 'MARKET',
+  'SUNDAY NOVEMBER 1ST 4 TO 9PM', 'THE EAGLE WILTON MANORS',
+  'TICKETS AT WWW.CLUBCHUBUSA.COM', '2209 WILTON DRIVE, WILTON MANORS, FL 33305'
+].join('\n');
+
+function buildFlyerEndFillParser(ocrText = MEAT_MARKET_FLYER_OCR, classification = 'event-flyer') {
+  const parser = createParser();
+  parser.recordOcrImageVerdict(MEAT_MARKET_FLYER_IMAGE, { imageClassification: classification, text: ocrText });
+  return parser;
+}
+
+function buildMeatMarketEvent(overrides = {}) {
+  return {
+    title: 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors',
+    // 4PM local — exactly what the page published (Nov 1 2026 is EST).
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: null,
+    timezone: 'America/New_York',
+    image: MEAT_MARKET_FLYER_IMAGE,
+    ...overrides
+  };
+}
+
+test('a missing end time is read off the flyer when its range starts at the published start', () => {
+  const parser = buildFlyerEndFillParser();
+  const event = buildMeatMarketEvent();
+
+  assert.equal(parser.fillEndTimeFromFlyerOcr([event]), 1);
+  // 9PM EST — the same instant the calendar record has held all along.
+  assert.equal(event.endDate.toISOString(), '2026-11-02T02:00:00.000Z');
+  assert.ok(Array.isArray(event._evidenceLines));
+  assert.match(event._evidenceLines.join('\n'), /read 16:00–21:00 off the event's flyer/);
+});
+
+test('flyer end-fill never overrides a stated end, and never runs without the evidence it needs', () => {
+  // A published end is authoritative — the flyer is not consulted.
+  const stated = buildMeatMarketEvent({ endDate: new Date('2026-11-02T04:00:00.000Z') });
+  assert.equal(buildFlyerEndFillParser().fillEndTimeFromFlyerOcr([stated]), 0);
+  assert.equal(stated.endDate.toISOString(), '2026-11-02T04:00:00.000Z', 'untouched');
+
+  // No timezone: a wall-clock reading would be a guess.
+  const zoneless = buildMeatMarketEvent({ timezone: '' });
+  assert.equal(buildFlyerEndFillParser().fillEndTimeFromFlyerOcr([zoneless]), 0);
+  assert.equal(zoneless.endDate, null);
+
+  // Wall-clock-as-UTC events are not yet on a real timeline.
+  const unresolved = buildMeatMarketEvent({ _timezoneUnresolved: true });
+  assert.equal(buildFlyerEndFillParser().fillEndTimeFromFlyerOcr([unresolved]), 0);
+
+  // Not a flyer: page furniture states nothing about this event's hours.
+  const logoVerdict = buildFlyerEndFillParser(MEAT_MARKET_FLYER_OCR, 'logo');
+  assert.equal(logoVerdict.fillEndTimeFromFlyerOcr([buildMeatMarketEvent()]), 0);
+
+  // Local midnight is the date-only default, not a stated start — nothing to
+  // anchor the flyer's range to.
+  const dateOnly = buildMeatMarketEvent({ startDate: new Date('2026-11-01T04:00:00.000Z') });
+  assert.equal(buildFlyerEndFillParser().fillEndTimeFromFlyerOcr([dateOnly]), 0);
+});
+
+test('flyer end-fill fails closed when the flyer does not agree with the page', () => {
+  // The flyer's range starts at 10PM; the page says 4PM. No agreement, no
+  // fill — this flyer is likely another night's artwork.
+  const otherNight = buildFlyerEndFillParser([
+    'CLUB CHUB', 'MEAT MARKET', 'SUNDAY NOVEMBER 1ST 10PM TO 2AM', 'THE EAGLE WILTON MANORS'
+  ].join('\n'));
+  const event = buildMeatMarketEvent();
+  assert.equal(otherNight.fillEndTimeFromFlyerOcr([event]), 0);
+  assert.equal(event.endDate, null);
+
+  // A flyer naming a date this event cannot be on is vetoed outright.
+  const wrongDate = buildFlyerEndFillParser([
+    'CLUB CHUB', 'MEAT MARKET', 'SATURDAY DECEMBER 5TH 2026 4 TO 9PM', 'THE EAGLE WILTON MANORS'
+  ].join('\n'));
+  assert.equal(wrongDate.fillEndTimeFromFlyerOcr([buildMeatMarketEvent()]), 0);
+
+  // A range with no end states nothing to adopt.
+  const startOnly = buildFlyerEndFillParser([
+    'CLUB CHUB', 'MEAT MARKET', 'SUNDAY NOVEMBER 1ST 4PM', 'THE EAGLE WILTON MANORS'
+  ].join('\n'));
+  assert.equal(startOnly.fillEndTimeFromFlyerOcr([buildMeatMarketEvent()]), 0);
+
+  // An implausible span (> 12h) reads more like an AM/PM slip than a party —
+  // the same shape sanity rule 11 corrects downstream.
+  const marathon = buildFlyerEndFillParser([
+    'CLUB CHUB', 'MEAT MARKET', 'SUNDAY NOVEMBER 1ST 4PM TO 9AM', 'THE EAGLE WILTON MANORS'
+  ].join('\n'));
+  const marathonEvent = buildMeatMarketEvent();
+  assert.equal(marathon.fillEndTimeFromFlyerOcr([marathonEvent]), 0);
+  assert.equal(marathonEvent.endDate, null);
+});
+
+test('a salvaged OCR read (text, no classification) still becomes usable evidence', () => {
+  const parser = createParser();
+  const url = 'https://res.cloudinary.com/eventservice/image/upload/saas/logos/salvaged.webp';
+  // The real shape the MEAT MARKET poster comes back in: the model buries the
+  // JSON under a run of newlines, the salvage keeps the words and loses the
+  // classification.
+  const salvaged = { text: 'CLUB CHUB\nMEAT MARKET\nSUNDAY NOVEMBER 1ST 4 TO 9PM' };
+
+  assert.equal(parser.recordOcrImageVerdict(url, salvaged), null,
+    'the classification verdict store still refuses an unclassified result');
+  const evidence = parser.recordOcrImageTextEvidence(url, salvaged);
+  assert.ok(evidence, 'the transcription is recorded as text evidence');
+  assert.equal(evidence.classification, '', 'with no classification claimed');
+  assert.match(parser.getOcrImageVerdict(url).text, /MEAT MARKET/);
+
+  // Fails open exactly like a missing verdict: an unclassified read never
+  // costs the event its image.
+  const event = { title: 'MEAT MARKET', image: url, imageSource: 'jsonld' };
+  parser.rejectNonEventImageValues(event);
+  assert.equal(event.image, url, 'an unclassified read is not a furniture verdict');
+
+  // Glyph noise is not evidence.
+  assert.equal(parser.recordOcrImageTextEvidence(url + '#noise', { text: 'm . ,' }), null);
+});
+
+test('the structured route reads its artwork and fills the missing end in one pass', async () => {
+  const parser = createParser();
+  const image = 'https://res.cloudinary.com/eventservice/image/upload/saas/logos/meat.webp';
+  parser.getOcrTextForImage = async () => ({
+    // Salvaged shape again — the path that used to record nothing at all.
+    text: 'CLUB CHUB\nCANNONBALL WEEKEND\nMEAT MARKET\nSUNDAY NOVEMBER 1ST 4 TO 9PM\nTHE EAGLE WILTON MANORS'
+  });
+  const events = [{
+    title: 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors',
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: null,
+    timezone: 'America/New_York',
+    image
+  }];
+
+  assert.equal(await parser.vetStructuredEventArtwork(events, {}, { fetchImageAsBase64: async () => 'ZmFrZQ==' }), 1);
+  assert.equal(parser.fillEndTimeFromFlyerOcr(events), 1);
+  assert.equal(events[0].endDate.toISOString(), '2026-11-02T02:00:00.000Z',
+    'the flyer-derived end matches the end this event has always had on the calendar');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3429,6 +3429,14 @@ class SharedCore {
                 // lookup failure falls through to existing behavior.
             }
         }
+        // Say so when the rung cannot run. Silence here is indistinguishable
+        // from "the evidence was read and did not decide", which is exactly
+        // what made the Club Chub flyer hard to diagnose: the run logged a
+        // URL-shape verdict and nothing about the evidence it never had.
+        if (textByUrl.size < 2) {
+            const unreadable = [imageA, imageB].filter(url => !textByUrl.has(url));
+            console.log(`🖼️ MERGE: image title-evidence unavailable — no OCR text for ${unreadable.length === 2 ? 'either image' : unreadable[0]}`);
+        }
         return textByUrl.size > 0 ? textByUrl : null;
     }
 
@@ -3649,10 +3657,44 @@ class SharedCore {
                         if (Array.isArray(evidenceTitleTokens) && evidenceTitleTokens.length >= 2) {
                             const matchedTitleTokensIn = (text) => {
                                 const ocrTokens = new Set(this.getCrossSourceTitleTokens(text));
-                                return evidenceTitleTokens.filter(token => ocrTokens.has(token)).length;
+                                return evidenceTitleTokens.filter(token => ocrTokens.has(token));
                             };
-                            const matchedA = matchedTitleTokensIn(evidenceTextA);
-                            const matchedB = matchedTitleTokensIn(evidenceTextB);
+                            const matchedTokensA = matchedTitleTokensIn(evidenceTextA);
+                            const matchedTokensB = matchedTitleTokensIn(evidenceTextB);
+                            // EXCLUSIVE-token test, ahead of the ratio test
+                            // below. Two flyers for the same promoter at the
+                            // same venue share nearly every title token, so a
+                            // ratio can be blocked by agreement: the real Club
+                            // Chub pair (run 20260828-163440) read 7 tokens
+                            // vs 5 — decisive to a human, one short of 2x, so
+                            // the rung fell through and the logo-path rung
+                            // then picked the STALE flyer. What actually
+                            // separates them is what only ONE image says:
+                            // "meat", "market" — the words the rename added.
+                            // Strict on purpose: the loser must name NONE of
+                            // the winner's exclusive tokens, and the winner
+                            // needs at least two, so a one-word coincidence
+                            // decides nothing.
+                            const exclusiveTo = (mine, theirs) => {
+                                const theirTokens = new Set(theirs);
+                                return mine.filter(token => !theirTokens.has(token));
+                            };
+                            const onlyA = exclusiveTo(matchedTokensA, matchedTokensB);
+                            const onlyB = exclusiveTo(matchedTokensB, matchedTokensA);
+                            if (onlyA.length >= 2 && onlyB.length === 0) {
+                                return {
+                                    winner: 'a',
+                                    reason: `flyer text alone names "${onlyA.join(' ')}" from the event's current title — OCR title evidence`
+                                };
+                            }
+                            if (onlyB.length >= 2 && onlyA.length === 0) {
+                                return {
+                                    winner: 'b',
+                                    reason: `flyer text alone names "${onlyB.join(' ')}" from the event's current title — OCR title evidence`
+                                };
+                            }
+                            const matchedA = matchedTokensA.length;
+                            const matchedB = matchedTokensB.length;
                             const winnerMatched = Math.max(matchedA, matchedB);
                             const loserMatched = Math.min(matchedA, matchedB);
                             if (winnerMatched >= 2

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20452,6 +20452,55 @@ test('image arbitration: OCR title evidence works both directions and beats no o
     'a side with no readable text never loses on evidence it could not present');
 });
 
+// The REAL transcriptions of both Club Chub flyers, read by the vision model
+// 2026-08-28. The fixtures above are kinder than reality: the actual Wig Out
+// poster also prints the venue, so the two flyers agree on "club chub eagle
+// wilton manors" and the ratio test (winner >= 2x loser) sees 7 vs 5 and
+// refuses — after which the logo-path rung picked the STALE flyer, because
+// sickening.events serves event artwork under /saas/logos/. What separates
+// them is what only one of them says.
+const REAL_WIG_OUT_OCR_TEXT = [
+  'CLUB CHUB', 'FORT LAUDERDALE FLORIDA', 'Wig Out', 'PARTY',
+  'SUNDAY NOVEMBER 1ST 2026 4-9PM', 'THE EAGLE WILTON MANORS', 'CANNONBALL WEEKEND',
+  'ADVANCED TICKETS', 'WWW.CLUBCHUBUSA.COM', '2208 WILTON DRIVE, WILTON MANORS, FL 33305'
+].join('\n');
+const REAL_MEAT_MARKET_OCR_TEXT = [
+  'CLUB CHUB', 'CANNONBALL WEEKEND', 'MEAT', 'MARKET',
+  'SUNDAY NOVEMBER 1ST 4 TO 9PM', 'THE EAGLE WILTON MANORS',
+  'TICKETS AT WWW.CLUBCHUBUSA.COM', '2209 WILTON DRIVE, WILTON MANORS, FL 33305'
+].join('\n');
+
+test('OCR title evidence decides on the tokens only ONE flyer names (real Club Chub transcriptions)', () => {
+  const core = createCore();
+  const context = buildOcrEvidenceContext({
+    [OLD_WIG_OUT_IMAGE]: REAL_WIG_OUT_OCR_TEXT,
+    [NEW_MEAT_MARKET_IMAGE]: REAL_MEAT_MARKET_OCR_TEXT
+  });
+  const resolved = core.resolveConflictDeterministically('image', OLD_WIG_OUT_IMAGE, NEW_MEAT_MARKET_IMAGE, context);
+  assert.ok(resolved, 'the rung decides instead of falling through to the URL shape');
+  assert.equal(resolved.winner, 'b', 'the flyer that says MEAT MARKET wins');
+  assert.match(resolved.reason, /OCR title evidence/);
+  assert.match(resolved.reason, /meat market/i, 'the reason names the deciding words');
+
+  // Symmetry: the same pair, sides swapped, must decide the same flyer.
+  const swapped = buildOcrEvidenceContext({
+    [NEW_MEAT_MARKET_IMAGE]: REAL_MEAT_MARKET_OCR_TEXT,
+    [OLD_WIG_OUT_IMAGE]: REAL_WIG_OUT_OCR_TEXT
+  });
+  const swappedResolved = core.resolveConflictDeterministically('image', NEW_MEAT_MARKET_IMAGE, OLD_WIG_OUT_IMAGE, swapped);
+  assert.equal(swappedResolved.winner, 'a', 'side order never changes which image wins');
+
+  // Strictness: a single exclusive token is a coincidence, not evidence. Both
+  // sides here name one title token the other lacks ("manors" / "market").
+  const oneEach = buildOcrEvidenceContext({
+    [OLD_WIG_OUT_IMAGE]: 'CLUB CHUB\nWIG OUT\nEAGLE WILTON MANORS',
+    [NEW_MEAT_MARKET_IMAGE]: 'CLUB CHUB\nMARKET NIGHT\nEAGLE WILTON'
+  });
+  const oneEachResolved = core.resolveConflictDeterministically('image', OLD_WIG_OUT_IMAGE, NEW_MEAT_MARKET_IMAGE, oneEach);
+  assert.ok(!oneEachResolved || !/OCR title evidence/.test(oneEachResolved.reason),
+    'both sides holding exclusive tokens falls through — no winner on split evidence');
+});
+
 test('createFinalEventObject preloads OCR texts through the injected lookup and updates the stale image', async () => {
   const core = createCore();
   const lookups = [];


### PR DESCRIPTION
Two symptoms, one cause: **the images that reach the calendar were never read.** The JSON-LD / JSON-API route returns before the OCR sweep, so the one flyer per event that actually ships was the only image in the system nobody looked at — and every decision about it was made from the shape of its URL.

## 1. The renamed event kept the old flyer

Club Chub's night was renamed Wig Out → MEAT MARKET. The page serves the real poster (1440×1920, full event copy), but sickening.events hosts event art under `/saas/logos/`, so:

```
🔒 MERGE: field=image resolved deterministically — event artwork beats logo-path image
```

The rung meant to prevent this already existed — OCR title evidence, directly above the logo-path test, its comment naming this exact case. It never fired: nothing had read the flyer, and even when handed both texts it still refused, because its ratio test wants the winner to name 2× the loser's title tokens:

```
title tokens: club chub presents meat market eagle wilton manors
Wig Out flyer     → 5: club chub eagle wilton manors
MEAT MARKET flyer → 7: club chub eagle wilton manors + meat market
needs winner >= 2 × loser → 7 >= 10 → refused
```

Two flyers from the same promoter at the same venue agree on nearly everything. The signal is what only **one** image says: `meat`, `market`.

## 2. The event had no end time, so it could not be saved at all

sickening.events publishes no `endDate`. EventKit refuses an event without an end — that is the write failure #1709 fixes at the merge. But the flyer said it all along: **"SUNDAY NOVEMBER 1ST 4 TO 9PM"**.

## The fix

- **`vetStructuredEventArtwork`** — OCR-reads each structured event's own image before anything judges it. One bounded call per distinct image, then the cache answers forever.
- **Exclusive-token test** in the image rung, ahead of the ratio test: the winner must name ≥2 title tokens the loser doesn't, and the loser none.
- **`fillEndTimeFromFlyerOcr`** — an absent end is read off the flyer when the flyer's range *starts at the time the page already publishes*. That agreement is the anti-hallucination gate. Fails closed on: a stated end, no timezone, a date-only (midnight) start, a flyer naming an impossible date, two disagreeing ranges, or a span over 12h.
- **Diagnostics** — log when image title-evidence is unavailable; silence read as "evidence considered".

Two blind spots surfaced while wiring it up, both the same mistake as the original bug:

- The vet was skipping `isLikelyUninterestingImageUrl` images — a URL-shape guess that calls the `/saas/logos/` poster uninteresting. Refusing to read the one image that reaches the calendar is how that guess became unfalsifiable.
- `recordOcrImageVerdict` refuses a result with no classification, and a **salvaged** read (text recovered from a truncated model reply) has exactly that shape — which is how this poster comes back every time. The store held nothing for the one flyer that mattered. Text-only evidence is now recorded under an empty classification, so furniture gates fail open exactly as they did on a missing verdict.

## Verification

Live page, end to end through the parser:

```
🤖 OCR-read structured-data artwork for "Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors" — unclassified (text recovered)
🕐 Filled missing end from flyer OCR — 16:00–21:00 local (5h)
  end     : 2026-11-02T02:00:00.000Z        ← the instant the calendar has always held
  evidence: endDate: read 16:00–21:00 off the event's flyer (page published no end time)
```

Live image decision, both flyers OCR'd:

```
{"winner":"b","reason":"flyer text alone names \"meat market\" from the event's current title — OCR title evidence"}
```

- Quiet suite: **1995 pass, 0 fail** (5 new).
- Regression tests use the vision model's **real transcriptions** of both posters. The previous fixtures were kinder than reality — they omitted the venue line both flyers share, which is exactly why this rung passed its tests and failed in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP

---

_Replaces #1710, which GitHub auto-closed when its base branch was deleted on #1709's merge. Same work, rebased onto `main` — the diff is now only the OCR changes._
