### PR TITLE
Bear it MTL lost two real events, invented a third, and took 7 minutes

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1092,7 +1092,16 @@ class ScriptableAdapter {
 
       return normalized.toString();
     } catch (_) {
-      return String(url || "").trim();
+      // Scriptable has no global URL, so this fallback is the ONLY path the
+      // phone ever takes — every entry it writes was stored unnormalized while
+      // the file NAME came from parsePageCacheUrl (hand-rolled, fragment-free).
+      // Clean filename, dirty payload: run 20260829-083010 read a cache entry
+      // keyed event__ensemble.json whose stored url was
+      // ".../event/ensemble/#tribe-tickets__tickets-form", and that anchored
+      // URL became ENSEMBLE's website all over again. At minimum the fragment
+      // must go — it is never part of the page's identity, which is exactly
+      // why the filename drops it.
+      return String(url || "").trim().split("#")[0];
     }
   }
 
@@ -1269,7 +1278,11 @@ class ScriptableAdapter {
 
       return {
         html: cached.html,
-        url: cached.url || normalizedUrl,
+        // Entries already on disk were written before the fallback above
+        // normalized anything, so heal them on read too rather than waiting
+        // out the 3-day TTL — the cache key never included the fragment, so a
+        // stored one is stale noise either way.
+        url: this.normalizePageCacheUrl(cached.url || normalizedUrl),
         statusCode: cached.statusCode || 200,
         headers: cached.headers || {},
         fetchedAt: cached.fetchedAt || null,

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -11097,3 +11097,33 @@ test('loadRunLogsForDisplay returns icloud-sync-pending (bounded) for an undownl
   const html = adapter.buildRunLogSectionHtml(logInfo);
   assert.ok(html.includes('still syncing from iCloud'), 'run-logs section explains the pending sync');
 });
+
+// Run 20260829-083010: the crawl fetched https://www.bearitmtl.com/event/ensemble/
+// and got a page-cache HIT, but the entry's stored url was
+// ".../event/ensemble/#tribe-tickets__tickets-form" — so the anchored URL became
+// ENSEMBLE's website all over again. The entry was written by the phone, where
+// there is no global URL: normalizePageCacheUrl's try-block never runs there, and
+// the old fallback returned the raw string while the FILE NAME (built by the
+// hand-rolled parsePageCacheUrl) had already dropped the fragment.
+test('page-cache URL normalization drops the fragment even without a global URL', () => {
+  const adapter = buildAdapter();
+  const anchored = 'https://www.bearitmtl.com/event/ensemble/#tribe-tickets__tickets-form';
+  const clean = 'https://www.bearitmtl.com/event/ensemble/';
+
+  assert.equal(adapter.normalizePageCacheUrl(anchored), clean, 'Node path (global URL present)');
+
+  const realUrl = global.URL;
+  global.URL = function ThrowingUrl() { throw new Error('no URL in Scriptable'); };
+  try {
+    assert.equal(adapter.normalizePageCacheUrl(anchored), clean, 'Scriptable fallback path');
+  } finally {
+    global.URL = realUrl;
+  }
+
+  // The cache key never carried the fragment, so both spellings share one file.
+  assert.deepEqual(
+    adapter.getPageCachePathParts(anchored),
+    adapter.getPageCachePathParts(clean),
+    'one page, one cache entry'
+  );
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -318,7 +318,11 @@ class WebAdapter {
 
             return normalized.toString();
         } catch (_) {
-            return String(url || '').trim();
+            // Twin of ScriptableAdapter.normalizePageCacheUrl's fallback — the
+            // fragment goes even here, because the cache FILENAME never
+            // included it and a payload that disagrees with its own key is
+            // just stale noise waiting to be read back as an event's website.
+            return String(url || '').trim().split('#')[0];
         }
     }
 
@@ -351,7 +355,11 @@ class WebAdapter {
     // canonical, so this replicates its regex path byte-for-byte.
     getDeviceParityPageCachePathParts(url) {
         // Device normalizePageCacheUrl: `new URL` throws (undefined) → catch.
-        const normalizedUrl = String(url || '').trim();
+        // That catch drops the #fragment (and only the fragment), so this
+        // replica must too or the two would disagree on the stored payload
+        // url. Filenames are unaffected either way — the regex path below
+        // never read the fragment into the name.
+        const normalizedUrl = String(url || '').trim().split('#')[0];
         const match = normalizedUrl.match(DEVICE_PARITY_URL_PARSE_REGEX);
         if (!match) {
             return {
@@ -488,7 +496,11 @@ class WebAdapter {
 
             return {
                 html: cached.html,
-                url: cached.url || normalizedUrl,
+                // Entries written before the fragment strip below (every entry
+                // the phone has ever written) stored the anchored URL beside a
+                // fragment-free filename; heal them on read rather than
+                // waiting out the TTL. See ScriptableAdapter for the twin.
+                url: this.normalizePageCacheUrl(cached.url || normalizedUrl),
                 statusCode: cached.statusCode || 200,
                 headers: cached.headers || {},
                 fetchedAt: cached.fetchedAt || null,

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -6002,18 +6002,36 @@ class AiWebParser {
             return false;
         }
 
-        const key = this.getUrlDedupeKey(url);
-        const score = this.scoreAdditionalUrl(url, sourceUrl, context);
+        // Validation ran on the URL as written (the fragment-only-root-url
+        // guard needs the fragment), but what gets CRAWLED and stored drops
+        // it: a fragment is a scroll target inside the same document, the
+        // fetch discards it, and getUrlDedupeKey already ignores it — so the
+        // only thing it can still do is ride into the event's url/website.
+        // Run 20260828-215643 crawled bearitmtl.com/event/ensemble/
+        // #tribe-tickets__tickets-form and rewrote ENSEMBLE's stored website
+        // to the anchored form on every single run.
+        const crawlUrl = this.stripUrlFragment(url);
+        const key = this.getUrlDedupeKey(crawlUrl);
+        const score = this.scoreAdditionalUrl(crawlUrl, sourceUrl, context);
         const existing = urls.get(key);
         if (!existing) {
-            urls.set(key, { url, score, index: urls.size });
+            urls.set(key, { url: crawlUrl, score, index: urls.size });
             return true;
         }
         if (score > existing.score) {
-            existing.url = url;
+            existing.url = crawlUrl;
             existing.score = score;
         }
         return false;
+    }
+
+    // Drop a URL's #fragment, leaving everything else byte-for-byte. Falls
+    // back to the input whenever the URL cannot be parsed (fail open — a URL
+    // this cannot read is one this must not rewrite).
+    stripUrlFragment(url) {
+        const text = String(url || '');
+        const hashIndex = text.indexOf('#');
+        return hashIndex === -1 ? text : text.slice(0, hashIndex);
     }
 
     looksLikeNonUrlJsFragment(rawUrl) {
@@ -10029,6 +10047,15 @@ class AiWebParser {
             'x.com',
             'instagram.com',
             'youtube.com',
+            // youtube.com's own aliases — neither matches the entry above
+            // (hostname equality or a ".youtube.com" suffix), so both were
+            // crawled as ordinary pages. Run 20260828-215643 followed
+            // youtu.be/r4IkE9JAtNo and www.youtube-nocookie.com/embed/… off
+            // bearitmtl.com/m-ours/, OCR'd the video thumbnail, and turned the
+            // poster on it into an "M.OURS 2025" event with a YouTube
+            // thumbnail for artwork and sugarbear.fr for a website.
+            'youtu.be',
+            'youtube-nocookie.com',
             'linkedin.com',
             'tiktok.com',
             'soundcloud.com',
@@ -10139,9 +10166,19 @@ class AiWebParser {
         // only: the ical/outlook-ical query flags, the tribe-bar-date query
         // param, and a .ics path suffix. The [?&] anchor keeps slugs like
         // "musical=1" or paths containing "ical" valid.
+        // Add-to-calendar / subscribe widgets are the same family: they encode
+        // an event (or a whole feed) into someone else's calendar UI, so the
+        // fetch returns that provider's app shell, never the event. Run
+        // 20260828-215643 crawled two outlook.live.com / outlook.office.com
+        // `rru=addsubscription` links off bearitmtl.com's archive. The Google
+        // `action=TEMPLATE` twin is already blocked by the google.com host
+        // entry; matching it here covers the other providers that use it.
         if (lowerPath.endsWith('.ics')
             || /[?&](?:outlook-)?ical=1(?!\d)/.test(lowerUrl)
-            || /[?&]tribe-bar-date=/.test(lowerUrl)) {
+            || /[?&]tribe-bar-date=/.test(lowerUrl)
+            || /[?&]rru=add(?:subscription|event)/.test(lowerUrl)
+            || /[?&]action=template(?:[&#]|$)/.test(lowerUrl)
+            || /webcal(?::|%3a)(?:\/\/|%2f%2f)/.test(lowerUrl)) {
             return { valid: false, reason: 'calendar-export-url' };
         }
         const blockedPattern = invalidUrlPatterns.find(invalid => {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7969,6 +7969,57 @@ test('validateEventUrl rejects calendar-export URLs (literal run URLs) but keeps
   assert.equal(parser.validateEventUrl('https://bear-it.example/events/musical-bears?musical=1', sourceUrl, {}).valid, true);
 });
 
+// Run 20260828-215643 (bearitmtl.com): the crawler followed the add-to-calendar
+// and subscribe widgets off the archive, and followed the site's YouTube recap
+// video off /m-ours/ — OCR'd its thumbnail and shipped the poster on it as an
+// "M.OURS 2025" event with a ytimg.com thumbnail for artwork.
+test('validateEventUrl rejects add-to-calendar widgets and every youtube.com alias', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://bear-it.example/events/';
+  const outlook = 'https://outlook.live.com/owa?path=/calendar/action/compose&rru=addsubscription'
+    + '&url=webcal%3A%2F%2Fbear-it.example%2F%3Fpost_type%3Dtribe_events%26ical%3D1';
+  assert.equal(parser.validateEventUrl(outlook, sourceUrl, {}).reason, 'calendar-export-url');
+  assert.equal(
+    parser.validateEventUrl('https://outlook.office.com/owa/?rru=addevent&startdt=2026-08-01T22%3A00%3A00', sourceUrl, {}).reason,
+    'calendar-export-url');
+  assert.equal(
+    parser.validateEventUrl('https://calendar.yahoo.com/?v=60&action=TEMPLATE&title=THE%20HUNT', sourceUrl, {}).reason,
+    'calendar-export-url');
+  assert.equal(
+    parser.validateEventUrl('webcal://bear-it.example/?post_type=tribe_events', sourceUrl, {}).valid, false);
+
+  // youtu.be and youtube-nocookie.com match neither "youtube.com" nor
+  // ".youtube.com", so both used to sail through as ordinary pages.
+  for (const video of [
+    'https://youtu.be/r4IkE9JAtNo',
+    'https://www.youtube-nocookie.com/embed/r4IkE9JAtNo?rel=0',
+    'https://www.youtube.com/watch?v=r4IkE9JAtNo'
+  ]) {
+    assert.equal(parser.validateEventUrl(video, sourceUrl, {}).valid, false, `${video} must not be crawled`);
+  }
+  // A real event page whose slug merely contains "template" is untouched.
+  assert.equal(parser.validateEventUrl('https://bear-it.example/event/template-party/', sourceUrl, {}).valid, true);
+});
+
+test('a discovered URL is crawled and stored without its #fragment', () => {
+  const parser = createParser();
+  const urls = new Map();
+  const sourceUrl = 'https://bear-it.example/events/';
+  parser.addAdditionalUrlCandidate(urls, 'https://bear-it.example/event/ensemble/#tribe-tickets__tickets-form', sourceUrl);
+  assert.deepEqual(
+    Array.from(urls.values()).map(entry => entry.url),
+    ['https://bear-it.example/event/ensemble/'],
+    'the anchor is a scroll target, not part of the page identity'
+  );
+  // The clean twin folds into the same entry rather than being crawled twice.
+  parser.addAdditionalUrlCandidate(urls, 'https://bear-it.example/event/ensemble/', sourceUrl);
+  assert.equal(urls.size, 1);
+  // An in-page anchor on the site root is still rejected outright.
+  assert.equal(
+    parser.validateEventUrl('https://bear-it.example/#content', sourceUrl, {}).reason,
+    'fragment-only-root-url');
+});
+
 // ---------------------------------------------------------------------------
 // Shared-meridiem time ranges (Fix: QUENCHD — "1-7PM" contains "7pm" but not
 // "1pm", so the evidence gate dropped the 13:00 start and it defaulted to

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -7023,7 +7023,19 @@ class SharedCore {
         const selected = [];
         const seen = new Set();
         const push = (candidate) => {
-            const normalized = this.normalizeUrl(candidate, pageUrl || candidate);
+            // A #fragment is a scroll target inside a document, never a
+            // different page — and whatever URL lands in this frontier becomes
+            // the crawled page's sourceUrl, which becomes the extracted
+            // event's url/website. The Events Calendar's own "Get tickets"
+            // anchors are exactly this shape, so run 20260828-215643 crawled
+            // bearitmtl.com/event/ensemble/#tribe-tickets__tickets-form and
+            // rewrote ENSEMBLE's stored website to the anchored form on every
+            // run. Discovery already strips fragments; ticket links reach the
+            // frontier through this path instead, so strip here too. The
+            // event's own ticketUrl keeps its anchor — jumping to the ticket
+            // form is what that link is FOR.
+            const withoutFragment = String(candidate || '').split('#')[0];
+            const normalized = this.normalizeUrl(withoutFragment, pageUrl || withoutFragment);
             if (!normalized || seen.has(normalized)) return;
             seen.add(normalized);
             selected.push(normalized);
@@ -16595,9 +16607,23 @@ class SharedCore {
 
     // Normalize scraped events and calendar events (which carry `name` instead of `title`
     // and stash extra fields in notes) into one comparable shape.
+    // A STATICALLY STAMPED shortName is deliberately left out of `names`:
+    // curated parser/promoter branding is pasted onto EVERY event the parser
+    // emits — "BEAR IT" on all 56 Bear it MTL records in run 20260828-215643 —
+    // so a shared value there is branding, not same-event evidence. Same
+    // reasoning getEventIdentityUrlKey already applies to a statically stamped
+    // `website`. An event's OWN shortName still counts (derived per event, or
+    // read out of a calendar record's notes): that is the renamed-event signal
+    // this shape was built for (#1440, "DALLAS FREEDOM TEA" vs "FURBALL").
     buildIdentityComparisonShape(event) {
         const fields = this.parseNotesIntoFields((event && (event.notes || event.unprocessedDescription)) || '');
-        const names = [event.title, event.name, event.originalTitle, event.shortName, fields.shortName]
+        const staticFields = event && event._staticFields && typeof event._staticFields === 'object'
+            ? event._staticFields
+            : {};
+        const shortNameIsBranding = Object.prototype.hasOwnProperty.call(staticFields, 'shortName');
+        const names = [event.title, event.name, event.originalTitle,
+            shortNameIsBranding ? '' : event.shortName,
+            shortNameIsBranding ? '' : fields.shortName]
             .map(value => String(value || '').trim())
             .filter(Boolean);
         return {
@@ -16614,6 +16640,20 @@ class SharedCore {
             locationText: typeof event.location === 'string' ? event.location : '',
             coordinates: this.parseCoordinatesForIdentity(event, fields)
         };
+    }
+
+    // Does either record carry the missing-time default — a start at exactly
+    // local midnight? That is the degraded shape getSameEventIdentitySignal's
+    // same-local-day relaxation exists to rescue (a listing stub that never
+    // stated a time, next to its properly-timed detail twin). A record whose
+    // local clock cannot be resolved at all counts as degraded too, so the
+    // relaxation still covers the cases it covered before this guard existed.
+    hasMissingTimeStartPlaceholder(...events) {
+        return events.some(event => {
+            if (!event || typeof event !== 'object') return false;
+            const parts = this.getMergeLocalStartParts(event);
+            return !parts || parts.minutesOfDay === 0;
+        });
     }
 
     areIdentityDatesOnSameLocalDay(shapeA, shapeB) {
@@ -16719,7 +16759,19 @@ class SharedCore {
 
         // Same place, roughly the same start time (tolerant of legacy wall-clock offsets),
         // and any pair of name-ish fields (title/name/shortName) similar.
-        if ((!requireCloseStartTimes || this.areDatesEqual(incoming.startDate, existing.startDate, 120)) &&
+        // The requireCloseStartTimes=false relaxation exists for ONE shape: a
+        // degraded scrape whose missing start time defaulted to local midnight
+        // must still match its properly-timed twin. It was never meant to let
+        // two records that EACH carry a real, precise, hours-apart time count
+        // as one event — run 20260828-215643 welded "Concours PUP Montréal"
+        // (18:00, Bain Mathieu) into "KINK Playground" (22:00, same venue,
+        // same night) and lost a real event. So the relaxation now requires
+        // that one side actually carry the midnight missing-time placeholder;
+        // otherwise the 2-hour window applies in both modes.
+        const startsAreClose = this.areDatesEqual(incoming.startDate, existing.startDate, 120);
+        const startsAreCompatible = startsAreClose
+            || (!requireCloseStartTimes && this.hasMissingTimeStartPlaceholder(newEvent, existingEvent));
+        if (startsAreCompatible &&
             this.areIdentityPlacesSimilar(incoming, existing) &&
             this.areIdentityNamesSimilar(incoming, existing)) {
             return requireCloseStartTimes ? 'place-time-name' : 'place-day-name';

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4652,6 +4652,95 @@ test('relaxed identity signal matches same-local-day despite degraded start time
   assert.equal(core.getSameEventIdentitySignal(a, b, { requireCloseStartTimes: false }), 'place-day-name');
 });
 
+// Run 20260828-215643 (Bear it MTL) folded two REAL events into one another and
+// lost them both from the output: bearitmtl.com ran "Concours PUP Montréal"
+// (18:00-21:00) and "KINK Playground" (22:00-03:00) at Bain Mathieu on the same
+// night, and "Tour de ville en Bus Rouge" (14:00, Aigle Noir) and "Concours M.
+// Ours 2026" (20:00, Stock Bar) on the same day. Two independent defects had to
+// line up: the promoter registry stamps shortName "BEAR IT" on every event the
+// parser emits (so any two records were trivially "name-similar"), and dedup's
+// relaxed scan dropped the start-time check entirely rather than only for the
+// degraded records it was written for.
+const BEAR_IT_CITIES = {
+  montreal: { timezone: 'America/Toronto', patterns: ['montreal'] }
+};
+function bearItRecord(overrides = {}) {
+  return {
+    shortName: 'BEAR IT',
+    _staticFields: { shortName: 'BEAR IT' },
+    city: 'montreal',
+    timezone: 'America/Toronto',
+    bar: 'Bain Mathieu',
+    address: '2915 Rue Ontario E, Montréal, QC, H2K 1X7',
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+test('curated promoter branding in shortName is not same-event evidence', () => {
+  const core = new SharedCore(BEAR_IT_CITIES, { eventSchema: EventSchema });
+  const pup = bearItRecord({ title: 'Concours PUP Montréal', startDate: new Date('2026-08-01T22:00:00.000Z') });
+  const kink = bearItRecord({ title: 'KINK Playground', startDate: new Date('2026-08-02T02:00:00.000Z') });
+  assert.equal(core.areTitlesSimilar(pup.title, kink.title), false, 'the titles themselves never matched');
+  assert.deepEqual(
+    core.buildIdentityComparisonShape(pup).names,
+    ['Concours PUP Montréal'],
+    'a statically stamped shortName is branding, so it stays out of the identity names'
+  );
+  // An event's OWN shortName is still identity evidence — that is the renamed-event
+  // signal (#1440) this shape exists for.
+  const derived = { title: 'FURBALL DALLAS', shortName: 'FURBALL' };
+  assert.deepEqual(core.buildIdentityComparisonShape(derived).names, ['FURBALL DALLAS', 'FURBALL']);
+});
+
+test('same-local-day relaxation needs a degraded start, not just the same night', async () => {
+  const core = new SharedCore(BEAR_IT_CITIES, { eventSchema: EventSchema });
+  const relaxed = { requireCloseStartTimes: false };
+  // Both records carry a real, precise time four hours apart — two different parties.
+  const pup = bearItRecord({ title: 'Concours PUP Montréal', startDate: new Date('2026-08-01T22:00:00.000Z') });
+  const kink = bearItRecord({ title: 'KINK Playground', startDate: new Date('2026-08-02T02:00:00.000Z') });
+  assert.equal(core.getSameEventIdentitySignal(kink, pup, relaxed), null);
+
+  // Same shape across two venues on one festival day.
+  const tour = bearItRecord({
+    title: 'Tour de ville en Bus Rouge – Avec Sasha BAGA',
+    bar: 'Départ devant L’aigle Noir',
+    address: '1315 Rue Sainte-Catherine E, Montréal',
+    startDate: new Date('2026-04-10T18:00:00.000Z')
+  });
+  const mours = bearItRecord({
+    title: 'Concours M. Ours 2026',
+    bar: 'Stock Bar',
+    address: '1171 Rue Ste Catherine Est, Montréal',
+    startDate: new Date('2026-04-11T00:00:00.000Z')
+  });
+  assert.equal(core.getSameEventIdentitySignal(mours, tour, relaxed), null);
+
+  // Both survive dedup as separate events rather than one chimera.
+  const deduped = await core.deduplicateEvents([pup, kink, tour, mours], null);
+  assert.deepEqual(
+    deduped.map(event => event.title).sort(),
+    ['Concours M. Ours 2026', 'Concours PUP Montréal', 'KINK Playground',
+      'Tour de ville en Bus Rouge – Avec Sasha BAGA'],
+    'four real events in, four real events out'
+  );
+});
+
+test('a midnight missing-time start still relaxes to same-local-day', () => {
+  const core = new SharedCore(BEAR_IT_CITIES, { eventSchema: EventSchema });
+  // The stub never stated a time, so it defaulted to local midnight; its detail
+  // twin carries the real 22:00. That is the shape the relaxation exists for.
+  const stub = bearItRecord({ title: 'KINK Playground', startDate: new Date('2026-08-01T04:00:00.000Z') });
+  const detail = bearItRecord({ title: 'KINK Playground', startDate: new Date('2026-08-02T02:00:00.000Z') });
+  assert.equal(core.hasMissingTimeStartPlaceholder(stub, detail), true);
+  assert.equal(
+    core.getSameEventIdentitySignal(detail, stub, { requireCloseStartTimes: false }),
+    'place-day-name'
+  );
+  // Neither side degraded → no relaxation.
+  assert.equal(core.hasMissingTimeStartPlaceholder(detail, detail), false);
+});
+
 test('filterEventsForExecution excludes events from dry-run parsers', () => {
   const live = { title: 'Live Event', _parserConfig: { name: 'Live Parser', dryRun: false } };
   const dry = { title: 'Dry Event', _parserConfig: { name: 'Dry Parser', dryRun: true } };
@@ -15485,6 +15574,31 @@ test('selectAdaptiveFollowLinks skips past ticketUrls at the unit level (string 
   assert.ok(!links.includes('https://eventim.us/event/old-string/2'));
   assert.ok(links.includes('https://tickets.example/new'));
   assert.ok(links.includes('https://tickets.example/undated'));
+});
+
+// Run 20260828-215643: The Events Calendar's "Get tickets" button links to the
+// event's own page with a #tribe-tickets__tickets-form anchor. That URL reached
+// the crawl frontier verbatim, became the crawled page's sourceUrl, and so
+// became ENSEMBLE's website — rewriting the calendar's clean URL every run.
+test('selectAdaptiveFollowLinks strips #fragments before they become a crawl sourceUrl', () => {
+  const core = createCore();
+  const future = new Date(Date.now() + 3 * DAY_MS);
+  const links = core.selectAdaptiveFollowLinks('event-page', [], {
+    events: [{
+      title: 'ENSEMBLE',
+      startDate: future,
+      ticketUrl: 'https://bear-it.example/event/ensemble/#tribe-tickets__tickets-form'
+    }]
+  }, 'https://bear-it.example/events/');
+  assert.deepEqual(links, ['https://bear-it.example/event/ensemble/']);
+  // The anchored spelling and the clean one are ONE page, so they collapse.
+  const both = core.selectAdaptiveFollowLinks('event-page', [], {
+    events: [
+      { title: 'A', startDate: future, ticketUrl: 'https://bear-it.example/event/ensemble/#tribe-tickets__tickets-form' },
+      { title: 'B', startDate: future, ticketUrl: 'https://bear-it.example/event/ensemble/' }
+    ]
+  }, 'https://bear-it.example/events/');
+  assert.equal(both.length, 1);
 });
 
 // Fix 6 — crawl-page failures were [ERROR]-logged but never counted: the run


### PR DESCRIPTION
Bear it MTL lost two real events, invented a third, and took 7 minutes

Crawled bearitmtl.com directly for ground truth: The Events Calendar publishes
exactly 14 events. Run 20260828-215643 produced 13 — 12 real, 2 lost, 1
invented — in 417s. Five independent defects, all generic:

1. Curated promoter branding counted as an event name. The registry stamps
   shortName "BEAR IT" on every event a parser emits, and
   buildIdentityComparisonShape fed it to the identity name check, so ANY two
   Bear it MTL records were "name-similar". A statically stamped shortName is
   now excluded — the same rule getEventIdentityUrlKey already applies to a
   statically stamped website. An event's own shortName still counts (the
   renamed-event signal from #1440).

2. The same-local-day dedup relaxation ignored real start times. It exists so a
   degraded scrape (missing time -> local midnight) still matches its properly
   timed twin, but it dropped the time check entirely. Combined with (1) that
   welded "Concours PUP Montreal" (18:00) into "KINK Playground" (22:00) at the
   same venue, and "Concours M. Ours 2026" (Stock Bar, 20:00) into "Tour de
   ville en Bus Rouge" (Aigle Noir, 14:00) — the AI arbiter even wrote "version
   two names a different event entirely" and merged anyway. The relaxation now
   requires one side to actually carry the midnight placeholder.

3. youtu.be and youtube-nocookie.com were not blocked (neither matches the
   existing youtube.com entry), so the crawler followed the site's recap video
   off /m-ours/, OCR'd the thumbnail, and shipped the poster on it as an
   "M.OURS 2025" event dated tomorrow, with a ytimg.com thumbnail for artwork,
   sugarbear.fr for a website and an invented FREQ=WEEKLY rrule. Add-to-calendar
   and subscribe widgets (rru=addsubscription, action=TEMPLATE, webcal://) join
   the existing ?ical=1 family.

4. #fragments rode into stored event URLs. The Events Calendar's "Get tickets"
   button points at the event's own page with a #tribe-tickets__tickets-form
   anchor; that URL reached the crawl frontier verbatim, became the page's
   sourceUrl, and became ENSEMBLE's website — rewriting the calendar's clean URL
   on every single run. Fragments are now stripped in URL discovery and in
   selectAdaptiveFollowLinks (the event's own ticketUrl keeps its anchor —
   jumping to the ticket form is what that link is for).

5. Page-cache payloads disagreed with their own keys. Scriptable has no global
   URL, so normalizePageCacheUrl ALWAYS lands in its catch on the phone and
   stored the raw anchored URL beside a fragment-free filename; the cached
   payload then replayed the anchor after (4) was fixed. Both adapters now strip
   the fragment in that fallback and heal old entries on read. Filenames are
   unchanged, so device parity holds.

Verified against the live site — run 20260829-083631:

  before: 13 events (2 lost, 1 invented), 417s, ENSEMBLE churning every run
  after : 14 events matching the site exactly, 0 errors, 0 fragments,
          8.7s warm / 37.8s cold, ENSEMBLE a clean no-op

Concours PUP Montreal and Concours M. Ours 2026 are back with their own flyers,
venues and pins; the M.OURS 2025 ghost is gone. Crawl went from 60 pages to 47.

Not changed: gmaps preferring address text over coordinates is deliberate
(generateGoogleMapsUrl), and past events are kept on purpose (allowPastEvents).

Still open, reported separately: covers read the hidden data-price attribute
(29-37 CAD) instead of the published price ($40-$50); og:image can downgrade a
JSON-LD image to a smaller derivative; and the day-by-day archive walk that
still costs ~21 page fetches would be moot if tribe sites used their REST API.
