### PR TITLE
Read the Wix event list that was already in the HTML

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -7472,6 +7472,61 @@ class AiWebParser {
         return null;
     }
 
+    // The LISTING-page twin of extractWixServerEventData. The same
+    // <script id="wix-warmup-data"> blob that carries ONE event on a
+    // /event-details/ page carries the WHOLE list on an event-list page, under
+    // appsWarmupData.<events-app-guid>.widgetTPASection_<deployment>.events.events[]
+    // — every event with its exact UTC instants, IANA timezone, venue name and
+    // full formatted address. Verified 2026-08-29 against clubchubusa.com
+    // (3 events) and chunk-party.com (17), both with hasMore:false, so the
+    // inline list is the complete list, already inside HTML the crawl fetched.
+    // Returns [] for anything absent, unparseable, or odd-shaped — a listing
+    // page with no warmup events leaves the extraction flow untouched.
+    // No tickets array exists per row on a listing page, so these records carry
+    // no cover; the detail-page path remains the only source of sticker prices.
+    extractWixServerEventList(html) {
+        if (!html || typeof html !== 'string') return [];
+        try {
+            const startMatch = html.match(/<script\b[^>]*\bid=["']wix-warmup-data["'][^>]*>/i);
+            if (!startMatch) return [];
+            const jsonString = this.extractJsonObject(html, startMatch.index + startMatch[0].length);
+            if (!jsonString) return [];
+            return this.findWixWarmupEventListNodes(JSON.parse(jsonString))
+                .map(node => this.buildWixServerEventRecord(node, []))
+                .filter(record => record && (record.slug || record.title));
+        } catch (error) {
+            return [];
+        }
+    }
+
+    // Both the events-app GUID and the widgetTPASection_<suffix> key are
+    // deployment-specific, so walk every app's sections rather than naming
+    // either. Shape guard: a `.events.events` array whose members look like
+    // event nodes (a title or a scheduling block).
+    findWixWarmupEventListNodes(warmup) {
+        const collected = [];
+        if (!warmup || typeof warmup !== 'object') return collected;
+        const apps = warmup.appsWarmupData && typeof warmup.appsWarmupData === 'object'
+            ? Object.values(warmup.appsWarmupData)
+            : [];
+        for (const app of apps) {
+            if (!app || typeof app !== 'object') continue;
+            for (const section of Object.values(app)) {
+                if (!section || typeof section !== 'object') continue;
+                const list = section.events && typeof section.events === 'object'
+                    ? section.events.events
+                    : null;
+                if (!Array.isArray(list)) continue;
+                for (const node of list) {
+                    if (node && typeof node === 'object' && (node.title || node.scheduling)) {
+                        collected.push(node);
+                    }
+                }
+            }
+        }
+        return collected;
+    }
+
     buildWixServerEventRecord(node, tickets) {
         const clean = (value) => typeof value === 'string' ? this.normalizeWhitespace(value) : '';
         const location = node.location && typeof node.location === 'object' ? node.location : {};
@@ -8192,15 +8247,32 @@ class AiWebParser {
             const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
             const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
             const record = this.extractWixServerEventData(html);
-            if (!record) return events;
+            // A listing page carries the whole list in the same blob; a detail
+            // page carries one event and no list. Both may be absent.
+            const listRecords = this.extractWixServerEventList(html);
+            if (!record && listRecords.length === 0) return events;
 
             const filledFields = new Set();
             const upgradedFields = new Set();
             let enrichedCount = 0;
             for (const event of events) {
                 if (!event || typeof event !== 'object') continue;
-                if (!this.wixServerRecordMatchesEvent(record, event, sourceUrl, events.length)) continue;
-                const { filled, upgraded } = this.fillEventFromWixServerRecord(event, record, cityConfig);
+                // The detail-page record wins when it applies — it is the only
+                // one carrying ticket prices. Otherwise pair against the list,
+                // and only when EXACTLY ONE row matches: two rows claiming one
+                // event is ambiguity, and ambiguity means no enrichment.
+                let applicable = record && this.wixServerRecordMatchesEvent(record, event, sourceUrl, events.length)
+                    ? record
+                    : null;
+                if (!applicable) {
+                    const matches = listRecords.filter(candidate => this.wixListRecordMatchesEvent(candidate, event));
+                    if (matches.length === 1) applicable = matches[0];
+                    else if (matches.length > 1) {
+                        console.log(`🤖 AI Web: Wix listing data skipped for "${event.title || 'event'}" — ${matches.length} rows matched, ambiguous`);
+                    }
+                }
+                if (!applicable) continue;
+                const { filled, upgraded } = this.fillEventFromWixServerRecord(event, applicable, cityConfig);
                 if (filled.length > 0 || upgraded.length > 0) {
                     enrichedCount += 1;
                     filled.forEach(field => filledFields.add(field));
@@ -8219,6 +8291,31 @@ class AiWebParser {
             console.warn(`🤖 AI Web: Wix server data enrichment failed — events unchanged: ${error.message}`);
         }
         return events;
+    }
+
+    // Same-event check for a LISTING record. The single-record matcher's
+    // "only one candidate on an /event-details/ page" fallback cannot apply
+    // here — a list has many candidates — so this pairs on positive evidence
+    // only: the slug in the event's own link, identical normalized titles, or
+    // the identical start instant. Listing titles drift from the Wix title
+    // ("Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors" vs "Club Chub
+    // Presents: Meat Market"), which is exactly why the start instant is a
+    // rung; the warmup start is an exact UTC instant, so equality is proof,
+    // not a guess. The caller enforces uniqueness on top of this.
+    wixListRecordMatchesEvent(record, event) {
+        if (!record || !event) return false;
+        const link = `${String(event.url || '')} ${String(event.website || '')}`.toLowerCase();
+        const slug = record.slug ? record.slug.toLowerCase() : '';
+        if (slug && link.includes(slug)) return true;
+        if (record.title && event.title
+            && this.normalizeEvidenceText(record.title) === this.normalizeEvidenceText(event.title)) return true;
+        if (record.startDateUtc instanceof Date && event.startDate) {
+            const eventStart = event.startDate instanceof Date ? event.startDate : new Date(event.startDate);
+            if (!Number.isNaN(eventStart.getTime()) && eventStart.getTime() === record.startDateUtc.getTime()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // Conservative same-event check: the warmup blob describes ONE event, so it
@@ -8283,6 +8380,28 @@ class AiWebParser {
                 filled.push('endDate');
             }
             delete event._timezoneUnresolved;
+        }
+        // Missing end, same start: Wix knows when the party ends even when the
+        // page text never says so. Gated on the two instants being the SAME
+        // moment, so the pair can never be spliced from two different events —
+        // and applied only to a blank end or the degenerate end===start the
+        // pipeline substitutes for a missing one, never over a real end time.
+        // Club Chub's Monster Ball (run 20260828-214732) shipped 04:00→04:00
+        // while the warmup blob had 04:00→10:00Z all along.
+        if (record.endDateUtc && record.startDateUtc && event.startDate) {
+            const eventStart = event.startDate instanceof Date ? event.startDate : new Date(event.startDate);
+            const eventEnd = event.endDate instanceof Date
+                ? event.endDate
+                : (event.endDate ? new Date(event.endDate) : null);
+            const endIsMissing = !eventEnd || Number.isNaN(eventEnd.getTime())
+                || eventEnd.getTime() === eventStart.getTime();
+            if (!Number.isNaN(eventStart.getTime())
+                && eventStart.getTime() === record.startDateUtc.getTime()
+                && endIsMissing
+                && record.endDateUtc.getTime() > record.startDateUtc.getTime()) {
+                event.endDate = record.endDateUtc;
+                filled.push('endDate');
+            }
         }
         return { filled, upgraded };
     }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15827,3 +15827,113 @@ test('the structured route reads its artwork and fills the missing end in one pa
   assert.equal(events[0].endDate.toISOString(), '2026-11-02T02:00:00.000Z',
     'the flyer-derived end matches the end this event has always had on the calendar');
 });
+
+// ---------------------------------------------------------------------------
+// Wix LISTING-page warmup events. The same wix-warmup-data blob that carries
+// one event on an /event-details/ page carries the WHOLE list on an event-list
+// page. Verified 2026-08-29 against the live sites: clubchubusa.com published
+// 3 rows and chunk-party.com 17, both hasMore:false, inside HTML the crawl had
+// already fetched. Enrichment only — it never creates events.
+// ---------------------------------------------------------------------------
+
+// Deployment-specific keys on purpose: BOTH the app GUID and the
+// widgetTPASection_<suffix> key vary per site, so the walk must name neither.
+const WIX_LISTING_HTML = `
+<html><head>
+<script type="application/json" id="wix-warmup-data">{"appsWarmupData":{"cafe1234-0000-4000-8000-000000000000":{"widgetTPASection_zz9plural":{"events":{"hasMore":false,"filterType":2,"events":[
+  {"title":"Club Chub Presents: The Monster Ball","slug":"club-chub-presents-the-monster-ball",
+   "location":{"name":"Falcon North","address":"2020 E Artesia Blvd, Long Beach, CA 90805, USA","coordinates":{"lat":33.8742,"lng":-118.1706},"fullAddress":{"city":"Long Beach","formattedAddress":"2020 E Artesia Blvd, Long Beach, CA 90805, USA"}},
+   "scheduling":{"config":{"startDate":"2026-11-01T04:00:00.000Z","endDate":"2026-11-01T10:00:00.000Z","timeZoneId":"America/Los_Angeles"}}},
+  {"title":"Club Chub Presents: Meat Market","slug":"club-chub-presents-meat-market",
+   "location":{"name":"Eagle Wilton Manors","address":"2209 Wilton Dr, Wilton Manors, FL 33305, USA","coordinates":{"lat":26.1553,"lng":-80.1395},"fullAddress":{"city":"Wilton Manors","formattedAddress":"2209 Wilton Dr, Wilton Manors, FL 33305, USA"}},
+   "scheduling":{"config":{"startDate":"2026-11-01T21:00:00.000Z","endDate":"2026-11-02T02:00:00.000Z","timeZoneId":"America/New_York"}}}
+]}}}}}</script>
+</head><body>event list</body></html>`;
+
+const LISTING_URL = 'https://www.clubchubusa.com/event-list';
+
+test('extractWixServerEventList reads every row under deployment-specific keys', () => {
+  const parser = createParser();
+  const RealURL = global.URL;
+  global.URL = undefined;   // Scriptable has no URL global
+  try {
+    const records = parser.extractWixServerEventList(WIX_LISTING_HTML);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records.map(r => r.slug),
+      ['club-chub-presents-the-monster-ball', 'club-chub-presents-meat-market']);
+    assert.equal(records[1].timezone, 'America/New_York');
+    assert.equal(records[1].endDateUtc.toISOString(), '2026-11-02T02:00:00.000Z');
+    // No tickets[] exists per listing row, so listing records never carry a cover.
+    assert.equal(records[0].cover, null);
+  } finally {
+    global.URL = RealURL;
+  }
+});
+
+test('extractWixServerEventList returns [] for absent, garbage or list-less blobs', () => {
+  const parser = createParser();
+  assert.deepEqual(parser.extractWixServerEventList('<html><body>nothing</body></html>'), []);
+  assert.deepEqual(parser.extractWixServerEventList(''), []);
+  assert.deepEqual(parser.extractWixServerEventList(null), []);
+  assert.deepEqual(
+    parser.extractWixServerEventList('<script type="application/json" id="wix-warmup-data">{broken'), []);
+  assert.deepEqual(
+    parser.extractWixServerEventList(WIX_WARMUP_HTML), [],
+    'a detail-page blob carries no list — that stays the single-record path'
+  );
+});
+
+test('Wix listing data fills a missing end time but never overwrites a real one', () => {
+  const parser = createParser();
+  // Monster Ball as the pipeline produced it: a missing end became end === start.
+  const monsterBall = {
+    title: 'Club Chub Presents The Monster Ball Long Beach',
+    startDate: new Date('2026-11-01T04:00:00.000Z'),
+    endDate: new Date('2026-11-01T04:00:00.000Z')
+  };
+  // Meat Market already has a real end (read off its flyer) — it must survive.
+  const meatMarket = {
+    title: 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors',
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: new Date('2026-11-02T02:00:00.000Z')
+  };
+  parser.applyWixServerDataEnrichment([monsterBall, meatMarket],
+    { html: WIX_LISTING_HTML, url: LISTING_URL }, {});
+
+  assert.equal(monsterBall.endDate.toISOString(), '2026-11-01T10:00:00.000Z', 'degenerate end filled');
+  assert.equal(monsterBall.timezone, 'America/Los_Angeles');
+  assert.equal(monsterBall.location, '33.8742, -118.1706');
+  assert.equal(meatMarket.endDate.toISOString(), '2026-11-02T02:00:00.000Z', 'real end untouched');
+  // Titles drifted from the Wix titles on BOTH rows, so the pairing came from
+  // the exact start instants.
+  assert.equal(meatMarket.address, '2209 Wilton Dr, Wilton Manors, FL 33305, USA');
+});
+
+test('Wix listing data never fills a start-mismatched or ambiguous event', () => {
+  const parser = createParser();
+  // Same night, different start → no instant match, no title match, no slug.
+  const wrongNight = { title: 'Some Other Party', startDate: new Date('2026-11-01T06:00:00.000Z') };
+  parser.applyWixServerDataEnrichment([wrongNight], { html: WIX_LISTING_HTML, url: LISTING_URL }, {});
+  assert.equal(wrongNight.timezone, undefined, 'no positive evidence, no enrichment');
+
+  // Two rows claiming one event is ambiguity — fail closed.
+  const twinHtml = WIX_LISTING_HTML.replace('2026-11-01T21:00:00.000Z', '2026-11-01T04:00:00.000Z');
+  const ambiguous = { title: 'Club Chub', startDate: new Date('2026-11-01T04:00:00.000Z') };
+  parser.applyWixServerDataEnrichment([ambiguous], { html: twinHtml, url: LISTING_URL }, {});
+  assert.equal(ambiguous.timezone, undefined, 'two matching rows must enrich nothing');
+});
+
+test('a detail-page record still wins over the listing rows (only it has ticket prices)', () => {
+  const parser = createParser();
+  // Detail blob AND a listing blob whose row would match the same event.
+  const bothHtml = WIX_WARMUP_HTML.replace('</head>', `
+<script type="application/json" id="wix-warmup-data">{"appsWarmupData":{"cafe1234-0000-4000-8000-000000000000":{"widgetTPASection_q":{"events":{"hasMore":false,"events":[
+  {"title":"CHUNK Portland - SUMMER BLOW OUT!","slug":"chunk-portland-summer-blow-out",
+   "location":{"name":"Nova PDX","address":"WRONG ADDRESS FROM LISTING"},
+   "scheduling":{"config":{"startDate":"2026-08-23T04:00:00.000Z","endDate":"2026-08-23T09:00:00.000Z","timeZoneId":"America/Los_Angeles"}}}
+]}}}}}</script></head>`);
+  const event = { title: 'CHUNK Portland - SUMMER BLOW OUT!' };
+  parser.applyWixServerDataEnrichment([event], { html: bothHtml, url: CHUNK_PAGE_URL }, PORTLAND_CITY_CONFIG);
+  assert.equal(event.cover, '$20.50-$30.75', 'ticket prices come from the detail record');
+  assert.equal(event.address, '722 E Burnside St, Portland, OR 97214, USA', 'detail address, not the listing row');
+});


### PR DESCRIPTION
Read the Wix event list that was already in the HTML

Checked what platform every configured site actually runs before building
anything, and the answer redirected the work.

The Events Calendar REST protocol I floated is NOT worth building: only two
configured sites run tribe (bearitmtl.com, bearssitges.org) and
bearssitges.org answers /wp-json/tribe/events/v1/events with
rest_no_route — the API is off. A protocol serving exactly one site is a
per-site rule wearing a protocol costume.

Wix is the real cluster: 5 configured sites, 4 running the Wix Events widget
(chunk-party, clubchubusa, ursamen/spookybear, thelumberyardbar; furball.nyc is
Wix but uses no events widget). And it needs no protocol at all — the data is
already in HTML the crawl fetches. extractWixServerEventData has read
<script id="wix-warmup-data"> since the detail-page work; on a LISTING page
that same blob carries the whole list under

  appsWarmupData.<app-guid>.widgetTPASection_<deployment>.events.events[]

with exact UTC instants, IANA timezone, venue name and full formatted address
per row. findWixWarmupEventNode only ever looked for EventsPageInitialState.event
(one event, detail page) and returned null for a listing page, so all of it was
being thrown away and re-derived by AI and OCR.

- extractWixServerEventList + findWixWarmupEventListNodes read every row.
  Both the app GUID and the widgetTPASection_<suffix> key are deployment
  specific, so the walk names neither.
- wixListRecordMatchesEvent pairs on positive evidence only — slug in the
  event's own link, identical normalized titles, or the identical start
  instant. Listing titles drift from the Wix title ("Club Chub Presents:
  MEAT MARKET @ Eagle Wilton Manors" vs "Club Chub Presents: Meat Market"),
  which is why the exact instant is a rung. Two rows matching one event is
  ambiguity and enriches nothing.
- The detail-page record still wins where it applies; it is the only surface
  carrying base ticket prices.
- One new fill: a missing end time, gated on the two START instants being the
  same moment, and applied only to a blank end or the degenerate end===start
  the pipeline substitutes for a missing one. Never over a real end.

Still enrichment only. No extra requests, no events created, no extraction step
skipped.

Verified against both live sites:

  Club Chub  (run 20260829-084916) — enriched 2 events:
    Monster Ball  04:00 -> 04:00   becomes   04:00 -> 10:00Z
    filled: location, timezone, address, startDate, endDate
  CHUNK      (run 20260829-084928) — enriched 10 events off the listing page,
    filled: location, city, endDate, timezone, startDate
    (per-detail-page enrichment unchanged, covers still upgraded)

Both runs 0 errors. Worth noting: MEAT MARKET's 4-9pm end, which we recovered
by OCR'ing the flyer last week, was sitting in this blob the whole time — the
OCR path now has a deterministic source agreeing with it.

Not covered: ursamen.org and thelumberyardbar.com carry the widget but publish
no inline rows (Lumberyard's copy has been abandoned since 2020), so they are
unaffected either way.
