### PR TITLE
An event's image was its own thumbnail, twice over

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1807,13 +1807,17 @@ class ScriptableAdapter {
   // first attempts at ~1568px reliably overflowed the vision model's context
   // (0 tokens, finish_reason "length") and only succeeded after retrying ≤1024,
   // so every large image paid a wasted round trip.
-  async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024) {
+  // `imageMeta` (optional out-param, same convention as callAiGenerate's
+  // diagnostics) receives the PRE-downscale pixel size. Callers measure the
+  // bytes this returns, which are the shrunken rendition — without this the
+  // real shape is lost and every OCR'd image records as <=maxDimension wide.
+  async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024, imageMeta = null) {
     return this.withNetworkResilience("image download", url, () =>
-      this.fetchImageAsBase64Once(url, timeoutSeconds, maxDimension),
+      this.fetchImageAsBase64Once(url, timeoutSeconds, maxDimension, imageMeta),
     );
   }
 
-  async fetchImageAsBase64Once(url, timeoutSeconds = 30, maxDimension = 1024) {
+  async fetchImageAsBase64Once(url, timeoutSeconds = 30, maxDimension = 1024, imageMeta = null) {
     let request = null;
     try {
       request = new Request(url);
@@ -1824,6 +1828,15 @@ class ScriptableAdapter {
       // finish_reason "length", so cap the longest side before encoding.
       const width = image.size ? image.size.width : 0;
       const height = image.size ? image.size.height : 0;
+      // Stamped for EVERY image, downscaled or not — the loaded image's own
+      // size is the truth, and the caller should never have to guess whether
+      // the bytes it gets back were resized.
+      if (imageMeta && typeof imageMeta === "object"
+          && Number.isFinite(width) && Number.isFinite(height)
+          && width > 0 && height > 0) {
+        imageMeta.originalWidth = Math.round(width);
+        imageMeta.originalHeight = Math.round(height);
+      }
       const longestSide = Math.max(width, height);
       if (maxDimension > 0 && longestSide > maxDimension) {
         const scale = maxDimension / longestSide;

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -1018,6 +1018,18 @@ class WebAdapter {
     // math, extracted so the downscale decision is unit-testable without
     // sharp or network. Mirrors ScriptableAdapter.fetchImageAsBase64Once's
     // inline DrawContext math exactly.
+    // Stamp the true pre-downscale size onto an optional out-param. Silent and
+    // harmless when no object was passed or the probe produced nothing usable —
+    // the caller then falls back to measuring the bytes, exactly as before.
+    static recordOriginalImageDimensions(imageMeta, width, height) {
+        if (!imageMeta || typeof imageMeta !== 'object') return;
+        const w = Number(width);
+        const h = Number(height);
+        if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return;
+        imageMeta.originalWidth = Math.round(w);
+        imageMeta.originalHeight = Math.round(h);
+    }
+
     static getDownscaledImageDimensions(width, height, maxDimension) {
         const w = Number(width);
         const h = Number(height);
@@ -1072,7 +1084,11 @@ class WebAdapter {
     // something else. JPEG re-encode matches ScriptableAdapter
     // (Data.fromJPEG): the downscaled rendition only ever feeds the vision
     // model, never the stored event image URL.
-    async downscaleImageBufferForOcr(buffer, maxDimension, url) {
+    // `imageMeta` (optional out-param, same convention as callAiGenerate's
+    // diagnostics) receives the PRE-downscale pixel size. Callers measure the
+    // bytes this returns, which are the shrunken rendition — without this the
+    // real shape is lost and every OCR'd image records as <=maxDimension wide.
+    async downscaleImageBufferForOcr(buffer, maxDimension, url, imageMeta = null) {
         if (!Number.isFinite(Number(maxDimension)) || Number(maxDimension) <= 0) return buffer;
         const capability = this.getImageResizeCapability();
         if (!capability) return buffer;
@@ -1080,13 +1096,14 @@ class WebAdapter {
             if (capability.kind === 'sharp') {
                 const image = capability.sharp(buffer);
                 const metadata = await image.metadata();
+                WebAdapter.recordOriginalImageDimensions(imageMeta, metadata.width, metadata.height);
                 const target = WebAdapter.getDownscaledImageDimensions(metadata.width, metadata.height, maxDimension);
                 if (!target) return buffer;
                 const resized = await image.resize(target.width, target.height).jpeg({ quality: 85 }).toBuffer();
                 console.log(`🌐 Web: Downscaled image ${metadata.width}x${metadata.height} → ${target.width}x${target.height} for OCR: ${url}`);
                 return resized;
             }
-            return await this.downscaleImageBufferWithSips(buffer, maxDimension, url);
+            return await this.downscaleImageBufferWithSips(buffer, maxDimension, url, imageMeta);
         } catch (error) {
             console.warn(`🌐 Web: Image downscale failed for ${url} (${error.message}) — sending full-size image; oversized images may overflow the vision model context`);
             return buffer;
@@ -1097,7 +1114,7 @@ class WebAdapter {
     // the same helper as the sharp leg (byte-identical passthrough when the
     // image already fits), then resample the longest side and re-encode JPEG.
     // Errors propagate to the caller's LOUD fallback.
-    async downscaleImageBufferWithSips(buffer, maxDimension, url) {
+    async downscaleImageBufferWithSips(buffer, maxDimension, url, imageMeta = null) {
         const os = require('os');
         const { execFile } = require('child_process');
         const tmpDir = this.fs.mkdtempSync(this.path.join(os.tmpdir(), 'chunky-ocr-resize-'));
@@ -1114,6 +1131,7 @@ class WebAdapter {
             const probe = await runSips(['-g', 'pixelWidth', '-g', 'pixelHeight', inPath]);
             const width = Number((probe.match(/pixelWidth:\s*(\d+)/) || [])[1]);
             const height = Number((probe.match(/pixelHeight:\s*(\d+)/) || [])[1]);
+            WebAdapter.recordOriginalImageDimensions(imageMeta, width, height);
             const target = WebAdapter.getDownscaledImageDimensions(width, height, maxDimension);
             if (!target) return buffer;
             await runSips(['-Z', String(Number(maxDimension)), '-s', 'format', 'jpeg', '-s', 'formatOptions', '85', inPath, '--out', outPath]);
@@ -1130,13 +1148,13 @@ class WebAdapter {
     // (0 tokens, finish_reason "length") on Node because this adapter used to
     // ignore the cap entirely — including the overflow retry's explicit 768px
     // request, which therefore returned identical bytes and was skipped.
-    async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024) {
+    async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024, imageMeta = null) {
         if (this.isNode) {
             try {
                 const response = await fetch(url, { signal: AbortSignal.timeout(timeoutSeconds * 1000) });
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
                 const buffer = await response.arrayBuffer();
-                const payload = await this.downscaleImageBufferForOcr(Buffer.from(buffer), maxDimension, url);
+                const payload = await this.downscaleImageBufferForOcr(Buffer.from(buffer), maxDimension, url, imageMeta);
                 return payload.toString('base64');
             } catch (error) {
                 throw new Error(`Failed to fetch image as base64: ${error.message}`);

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -991,6 +991,11 @@ class AiWebParser {
         // value overflow retries used to succeed at), so this safety net steps
         // down further and should rarely fire.
         this.ocrOverflowRetryMaxDimension = 768;
+        // Both adapters cap an OCR payload's longest side here (their
+        // fetchImageAsBase64 default). Used only to judge whether a cached
+        // dimension pair written before the pre-downscale stamp existed could
+        // be a cap artifact — see isTrustworthyCachedImagePixels.
+        this.ocrDownscaleMaxDimension = 1024;
         this.defaultOcrRequestConfig = {
             // With requests serialized (maxConcurrentRequests), anything slower than
             // 2 minutes on the local vision model is stuck, not slow.
@@ -6667,7 +6672,7 @@ class AiWebParser {
             // still answer orientation — a hit never re-downloads the bytes.
             // Absent on entries written before this field; absent just means
             // "not measured", never a guess.
-            if (cached && cached.imagePixels) {
+            if (cached && cached.imagePixels && this.isTrustworthyCachedImagePixels(cached)) {
                 for (const url of [imageUrl, cached.url, normalizedUrl]) {
                     this.recordMeasuredImageDimensions(url, cached.imagePixels);
                 }
@@ -6719,7 +6724,29 @@ class AiWebParser {
         }
     }
 
-    async writeCachedOcrResult(imageUrl, ocrConfig = {}, text = '', imagePixels = null) {
+    // Entries written before the adapters reported their pre-downscale size
+    // stored whatever the OCR payload measured — which, for any image the
+    // adapter shrank, is the SHRUNKEN shape. `imagePixelsSource: 'original'`
+    // marks dimensions that came from the image itself and is always trusted.
+    // Without that stamp, distrust only the fingerprint of a capped rendition:
+    // a longest side landing exactly on a downscale cap, since the resize sets
+    // it to precisely that. Everything else measured the bytes as delivered
+    // (adapters with no resize capability never shrink anything) and stays
+    // trusted, so this removes no information that was ever reliable. A real
+    // image measuring exactly 1024 loses nothing but this shortcut —
+    // orientation still has every other piece of evidence it always had.
+    isTrustworthyCachedImagePixels(cached) {
+        if (!cached || typeof cached !== 'object' || !cached.imagePixels) return false;
+        if (cached.imagePixelsSource === 'original') return true;
+        const width = Number(cached.imagePixels.width);
+        const height = Number(cached.imagePixels.height);
+        if (!Number.isFinite(width) || !Number.isFinite(height)) return false;
+        const longestSide = Math.max(width, height);
+        return longestSide !== this.ocrDownscaleMaxDimension
+            && longestSide !== this.ocrOverflowRetryMaxDimension;
+    }
+
+    async writeCachedOcrResult(imageUrl, ocrConfig = {}, text = '', imagePixels = null, imagePixelsSource = null) {
         if (!ocrConfig.cacheEnabled) return null;
         const resultText = String(text || '').trim();
         if (resultText === undefined || resultText === null) return null;
@@ -6738,6 +6765,7 @@ class AiWebParser {
             cachedAt: new Date().toISOString(),
             cacheKeyVersion: 1,
             ...(measuredPixels ? { imagePixels: measuredPixels } : {}),
+            ...(measuredPixels && imagePixelsSource ? { imagePixelsSource } : {}),
             request: {
                 endpoint: String(ocrConfig.endpoint || ''),
                 model: String(ocrConfig.model || ''),
@@ -7015,10 +7043,19 @@ class AiWebParser {
             console.warn(`🤖 AI Web: JSON-LD event extraction failed: ${error.message}`);
             return [];
         }
+        // Yoast (and every other WordPress SEO plugin) publishes ONE @graph per
+        // page and refers between its nodes by @id, so an Event's image is
+        // routinely {"@id": ".../#primaryimage"} pointing at an ImageObject
+        // sibling that holds the real contentUrl AND its published width/height.
+        // Without the index that reference reads as "no image", and the og:image
+        // fill then supplies WordPress's 1024px derivative instead — which is
+        // how THE HUNT shipped a 1024x539 thumbnail of a 2050x1080 flyer
+        // (run 20260828-215643).
+        const nodesById = this.indexJsonLdNodesById(html);
         const events = [];
         const seen = new Set();
         for (const node of nodes) {
-            const event = this.buildEventFromJsonLdNode(node, sourceUrl, cityConfig);
+            const event = this.buildEventFromJsonLdNode(node, sourceUrl, cityConfig, nodesById);
             if (!event) continue;
             const key = `${event.title.toLowerCase()}|${event.startDate.toISOString()}`;
             if (seen.has(key)) continue;
@@ -7028,7 +7065,53 @@ class AiWebParser {
         return events;
     }
 
-    buildEventFromJsonLdNode(node, sourceUrl, cityConfig = null) {
+    // Map of "@id" → node for every object in the page's JSON-LD, so an @id
+    // reference can be followed to the node that actually holds the data.
+    // Returns an empty Map for anything absent or unparseable; a caller with no
+    // index behaves exactly as it did before this existed.
+    indexJsonLdNodesById(html) {
+        const index = new Map();
+        const source = String(html || '');
+        if (!source.includes('ld+json')) return index;
+        const scriptPattern = /<script[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+        let match;
+        while ((match = scriptPattern.exec(source)) !== null) {
+            let parsed;
+            try {
+                parsed = JSON.parse(match[1].trim());
+            } catch (_) {
+                continue;
+            }
+            this.collectJsonLdNodesById(parsed, index, 0);
+        }
+        return index;
+    }
+
+    collectJsonLdNodesById(node, index, depth) {
+        if (!node || depth > 6) return;
+        if (Array.isArray(node)) {
+            for (const child of node) this.collectJsonLdNodesById(child, index, depth + 1);
+            return;
+        }
+        if (typeof node !== 'object') return;
+        const id = typeof node['@id'] === 'string' ? node['@id'].trim() : '';
+        // Richest node wins. The SAME @id appears once as the real node and
+        // once per reference to it — and the references usually come FIRST in
+        // document order (Yoast's WebPage points at #primaryimage above the
+        // ImageObject that defines it), so "first writer wins" would index the
+        // empty pointer and resolve every lookup back to itself.
+        if (id) {
+            const existing = index.get(id);
+            if (!existing || Object.keys(node).length > Object.keys(existing).length) {
+                index.set(id, node);
+            }
+        }
+        for (const value of Object.values(node)) {
+            if (value && typeof value === 'object') this.collectJsonLdNodesById(value, index, depth + 1);
+        }
+    }
+
+    buildEventFromJsonLdNode(node, sourceUrl, cityConfig = null, nodesById = null) {
         if (!node || typeof node !== 'object') return null;
         const clean = (value) => this.normalizeWhitespace(
             this.decodeBasicEntities(this.stripTags(String(value || ''))).replace(/&amp;/gi, '&')
@@ -7062,7 +7145,7 @@ class AiWebParser {
         const offerUrl = offer && typeof offer === 'object' ? this.normalizeHttpUrlValue(offer.url) : '';
         const ticketUrl = offerUrl || this.normalizeHttpUrlValue(node.url) || '';
         const cover = this.formatJsonLdOffersCover(node.offers);
-        const jsonLdImageCandidates = this.pickJsonLdImageCandidates(node.image);
+        const jsonLdImageCandidates = this.pickJsonLdImageCandidates(node.image, nodesById);
 
         const event = {
             title,
@@ -7299,11 +7382,17 @@ class AiWebParser {
     // slots want — so the array is read whole instead of collapsing to [0].
     // ImageObject entries carry authoritative width/height; those beat anything
     // guessed from the URL.
-    pickJsonLdImageCandidates(image) {
+    pickJsonLdImageCandidates(image, nodesById = null) {
         const raw = Array.isArray(image) ? image : [image];
         const candidates = [];
         const seen = new Set();
-        for (const entry of raw) {
+        for (const rawEntry of raw) {
+            // Follow an @id reference to the ImageObject that holds the real
+            // url/contentUrl and its published dimensions. Only when the entry
+            // carries no usable url of its own, so a node that has both keeps
+            // what it states. One hop only — a reference to a reference is a
+            // malformed graph, not a shape to chase.
+            const entry = this.resolveJsonLdImageReference(rawEntry, nodesById);
             let url = '';
             let width = null;
             let height = null;
@@ -7311,8 +7400,14 @@ class AiWebParser {
                 // JSON-LD events skip normalizeAiEvent, so upgrade degraded CDN
                 // thumbnails here — the stored image must never be a blurred preview.
                 url = this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(entry) || '') || '';
-            } else if (entry && typeof entry === 'object' && typeof entry.url === 'string') {
-                url = this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(entry.url) || '') || '';
+            } else if (entry && typeof entry === 'object') {
+                // contentUrl is schema.org's canonical "the actual bytes" key;
+                // Yoast's ImageObject nodes publish both, identical.
+                const stated = typeof entry.url === 'string' && entry.url.trim()
+                    ? entry.url
+                    : (typeof entry.contentUrl === 'string' ? entry.contentUrl : '');
+                if (!stated) continue;
+                url = this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(stated) || '') || '';
                 width = this.parseImageDimensionValue(entry.width);
                 height = this.parseImageDimensionValue(entry.height);
             }
@@ -7323,6 +7418,28 @@ class AiWebParser {
             candidates.push({ url, width, height, authoritative: Boolean(width && height) });
         }
         return candidates;
+    }
+
+    // An image entry that is only a pointer ({"@id": "…#primaryimage"}, or a
+    // bare "#…" string) resolved against the page's node index. Returns the
+    // entry unchanged when it already carries a url, when there is no index, or
+    // when the id names nothing — every miss leaves the old behaviour intact.
+    resolveJsonLdImageReference(entry, nodesById) {
+        if (!nodesById || typeof nodesById.get !== 'function') return entry;
+        let id = '';
+        if (typeof entry === 'string') {
+            // A plain string is a URL unless it is only a fragment/id pointer.
+            if (!entry.trim().startsWith('#')) return entry;
+            id = entry.trim();
+        } else if (entry && typeof entry === 'object') {
+            const hasOwnUrl = (typeof entry.url === 'string' && entry.url.trim())
+                || (typeof entry.contentUrl === 'string' && entry.contentUrl.trim());
+            if (hasOwnUrl) return entry;
+            id = typeof entry['@id'] === 'string' ? entry['@id'].trim() : '';
+        }
+        if (!id) return entry;
+        const target = nodesById.get(id);
+        return target && target !== entry ? target : entry;
     }
 
     pickJsonLdImage(image) {
@@ -9850,8 +9967,15 @@ class AiWebParser {
         }
         const downloadStart = Date.now();
         let base64Image;
+        // Out-param: the adapters cap the longest side at 1024 before handing
+        // the bytes over, so measuring those bytes records a shrunken shape for
+        // every OCR'd image. bearitmtl.com's The-Hunt.jpg (a real 2050x1080)
+        // and its own 1024x539 WordPress derivative BOTH recorded 1024x539 in
+        // run 20260828-215643, which left the slot ranking unable to tell an
+        // original from its thumbnail — and the thumbnail won.
+        const imageMeta = {};
         try {
-            base64Image = await httpAdapter.fetchImageAsBase64(normalizedUrl, ocrConfig.timeoutSeconds);
+            base64Image = await httpAdapter.fetchImageAsBase64(normalizedUrl, ocrConfig.timeoutSeconds, undefined, imageMeta);
         } catch (error) {
             console.warn(`🚨 AI Web: OCR image download failed for ${normalizedUrl} after ${Date.now() - downloadStart}ms: ${error.message}`);
             throw error;
@@ -9861,7 +9985,11 @@ class AiWebParser {
         // before they go to the vision model. No second fetch, and orientation
         // then works for every image OCR touched, not just the rare few whose
         // URL or meta tags happen to advertise dimensions.
-        const measuredPixels = this.measureImageDimensionsFromBase64(imageUrl, base64Image);
+        // The adapter's pre-downscale size is the truth when it reported one;
+        // the header read of the (possibly shrunken) payload is the fallback,
+        // which is exactly what every path did before the out-param existed.
+        const measuredPixels = this.pickTrueImageDimensions(imageMeta)
+            || this.measureImageDimensionsFromBase64(imageUrl, base64Image);
         if (measuredPixels) {
             // The event's image value can be either the URL as found on the
             // page or its proxy-unwrapped form — point both at the measurement.
@@ -9938,7 +10066,11 @@ class AiWebParser {
         }
         const normalized = this.normalizeOcrResult(parsed);
         this.recordOcrImageVerdict(imageUrl, { ...normalized, imageUrl });
-        const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, JSON.stringify(parsed), measuredPixels);
+        const cachePath = await this.writeCachedOcrResult(
+            imageUrl, ocrConfig, JSON.stringify(parsed), measuredPixels,
+            // Only a pre-downscale stamp describes the image itself; a header
+            // read of the payload describes whatever the adapter handed over.
+            this.pickTrueImageDimensions(imageMeta) ? 'original' : 'payload');
         return {
             imageUrl,
             text: normalized.text,
@@ -18396,6 +18528,18 @@ TEXT:
     // Read an image's real shape out of the base64 payload the OCR pass just
     // downloaded, and remember it for the orientation slots. Returns the
     // measured {width, height} or null; never throws.
+    // {width, height} from an adapter's pre-downscale stamp, or null when the
+    // adapter reported nothing usable (an older adapter, a browser build, a
+    // probe that failed). Fails closed to null so the header measurement is
+    // still consulted.
+    pickTrueImageDimensions(imageMeta) {
+        if (!imageMeta || typeof imageMeta !== 'object') return null;
+        const width = Number(imageMeta.originalWidth);
+        const height = Number(imageMeta.originalHeight);
+        if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+        return { width: Math.round(width), height: Math.round(height) };
+    }
+
     measureImageDimensionsFromBase64(imageUrl, base64Image) {
         try {
             const dimensions = this.readImageDimensionsFromBase64(base64Image);

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15937,3 +15937,95 @@ test('a detail-page record still wins over the listing rows (only it has ticket 
   assert.equal(event.cover, '$20.50-$30.75', 'ticket prices come from the detail record');
   assert.equal(event.address, '722 E Burnside St, Portland, OR 97214, USA', 'detail address, not the listing row');
 });
+
+// ---------------------------------------------------------------------------
+// JSON-LD @id references. WordPress SEO plugins publish ONE @graph per page and
+// refer between its nodes by @id, so an Event's image is routinely a pointer at
+// an ImageObject sibling holding the real contentUrl and its published size.
+// Reading that pointer as "no image" let the og:image fill supply WordPress's
+// 1024px derivative instead — THE HUNT shipped a 1024x539 thumbnail of a
+// 2050x1080 flyer in run 20260828-215643.
+// ---------------------------------------------------------------------------
+
+// Real bearitmtl.com/event/the-hunt/ shape: the Event lives in its own script,
+// the ImageObject it points at lives in the OTHER script's @graph, and the
+// WebPage reference to it appears BEFORE the node that defines it.
+const JSONLD_ID_REFERENCE_HTML = `
+<html><head>
+<script type="application/ld+json">{"@context":"https://schema.org","@graph":[
+ {"@type":"WebPage","@id":"https://site.example/event/the-hunt/","image":{"@id":"https://site.example/event/the-hunt/#primaryimage"}},
+ {"@type":"ImageObject","@id":"https://site.example/event/the-hunt/#primaryimage",
+  "url":"https://site.example/uploads/The-Hunt.jpg","contentUrl":"https://site.example/uploads/The-Hunt.jpg",
+  "width":2050,"height":1080}
+]}</script>
+<script type="application/ld+json">[{"@context":"http://schema.org","@type":"Event","name":"THE HUNT",
+ "startDate":"2026-09-06T21:00:00-04:00","endDate":"2026-09-07T03:00:00-04:00",
+ "image":{"@id":"https://site.example/event/the-hunt/#primaryimage"},
+ "url":"https://site.example/event/the-hunt/"}]</script>
+<meta property="og:image" content="https://site.example/uploads/The-Hunt-1024x539.jpg" />
+</head><body>THE HUNT</body></html>`;
+
+test('a JSON-LD image given as an @id reference resolves to the node that defines it', () => {
+  const parser = createParser();
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const events = parser.extractEventsFromJsonLd(JSONLD_ID_REFERENCE_HTML, 'https://site.example/event/the-hunt/', {});
+  assert.equal(events.length, 1);
+  assert.equal(events[0].image, 'https://site.example/uploads/The-Hunt.jpg',
+    'the full-size original, not the og:image derivative');
+});
+
+test('the @id index keeps the node that defines an id, not a reference to it', () => {
+  const parser = createParser();
+  const index = parser.indexJsonLdNodesById(JSONLD_ID_REFERENCE_HTML);
+  const target = index.get('https://site.example/event/the-hunt/#primaryimage');
+  assert.ok(target, 'the id must be indexed');
+  assert.equal(target.width, 2050, 'the ImageObject wins over the earlier bare pointer');
+
+  // The published dimensions ride along, so the slot ranking gets them for free.
+  const candidates = parser.pickJsonLdImageCandidates(
+    { '@id': 'https://site.example/event/the-hunt/#primaryimage' }, index);
+  assert.deepEqual(candidates.map(c => [c.url, c.width, c.height, c.authoritative]),
+    [['https://site.example/uploads/The-Hunt.jpg', 2050, 1080, true]]);
+});
+
+test('@id resolution never disturbs images that state their own url', () => {
+  const parser = createParser();
+  const index = parser.indexJsonLdNodesById(JSONLD_ID_REFERENCE_HTML);
+  // A plain string URL is untouched.
+  assert.deepEqual(parser.pickJsonLdImageCandidates('https://site.example/own.jpg', index).map(c => c.url),
+    ['https://site.example/own.jpg']);
+  // An object carrying BOTH an @id and a url keeps its own url.
+  assert.deepEqual(parser.pickJsonLdImageCandidates(
+    { '@id': 'https://site.example/event/the-hunt/#primaryimage', url: 'https://site.example/own.jpg' }, index
+  ).map(c => c.url), ['https://site.example/own.jpg']);
+  // contentUrl alone is enough (schema.org's canonical "the actual bytes" key).
+  assert.deepEqual(parser.pickJsonLdImageCandidates({ contentUrl: 'https://site.example/bytes.jpg' }).map(c => c.url),
+    ['https://site.example/bytes.jpg']);
+  // An id naming nothing, and no index at all, both fail open to no candidate.
+  assert.deepEqual(parser.pickJsonLdImageCandidates({ '@id': 'https://site.example/#nope' }, index), []);
+  assert.deepEqual(parser.pickJsonLdImageCandidates({ '@id': 'https://site.example/#primaryimage' }), []);
+});
+
+test('cached OCR dimensions are distrusted only when they look like a downscale cap', () => {
+  const parser = createParser();
+  const stamped = { imagePixels: { width: 2050, height: 1080 }, imagePixelsSource: 'original' };
+  assert.equal(parser.isTrustworthyCachedImagePixels(stamped), true);
+  // Unstamped and sitting exactly on a cap — could be a real image or a shrunken
+  // one, and guessing wrong is what let a thumbnail beat its own original.
+  assert.equal(parser.isTrustworthyCachedImagePixels({ imagePixels: { width: 1024, height: 539 } }), false);
+  assert.equal(parser.isTrustworthyCachedImagePixels({ imagePixels: { width: 405, height: 768 } }), false);
+  // Unstamped but nowhere near a cap: measured as delivered, still trusted.
+  assert.equal(parser.isTrustworthyCachedImagePixels({ imagePixels: { width: 1155, height: 1540 } }), true);
+  assert.equal(parser.isTrustworthyCachedImagePixels({ imagePixels: { width: 800, height: 600 } }), true);
+  assert.equal(parser.isTrustworthyCachedImagePixels({}), false);
+});
+
+test('an adapter that reports its pre-downscale size beats measuring the shrunken payload', () => {
+  const parser = createParser();
+  assert.deepEqual(parser.pickTrueImageDimensions({ originalWidth: 2050, originalHeight: 1080 }),
+    { width: 2050, height: 1080 });
+  // Nothing usable reported → null, so the header measurement is still consulted.
+  assert.equal(parser.pickTrueImageDimensions({}), null);
+  assert.equal(parser.pickTrueImageDimensions({ originalWidth: 0, originalHeight: 10 }), null);
+  assert.equal(parser.pickTrueImageDimensions(null), null);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1484,6 +1484,43 @@ class SharedCore {
     // segments; when a URL advertises nothing, the URL length is a weak
     // fallback signal (kept for parser parity — the merge rung's margin guard
     // deliberately ignores that noise floor).
+    // WordPress stores every upload as `name.ext` plus a family of resized
+    // siblings named `name-WIDTHxHEIGHT.ext`. The bare name IS the original, so
+    // when two URLs are the same upload and exactly one carries that suffix,
+    // the bare one wins — no size comparison can get this right, because the
+    // original advertises nothing and the derivative advertises its smaller
+    // self. Returns {winner, reason} or null; null means "not this shape" and
+    // the caller's normal scoring proceeds.
+    // Both bare or both resized is not this shape either: two different
+    // derivatives are a real size comparison, which the score rung handles.
+    pickWordPressOriginalImage(valueA, valueB) {
+        const shapeOf = (value) => {
+            const raw = String(value || '').trim();
+            if (!raw) return null;
+            const parsed = this.parseUrl(raw);
+            const path = parsed ? String(parsed.pathname || '') : raw.split(/[?#]/)[0];
+            if (!path) return null;
+            const match = path.match(/^(.*)-(\d{2,5})x(\d{2,5})(\.[A-Za-z0-9]+)$/);
+            return match
+                ? { base: `${match[1]}${match[4]}`, resized: true }
+                : { base: path, resized: false };
+        };
+        const a = shapeOf(valueA);
+        const b = shapeOf(valueB);
+        if (!a || !b || a.resized === b.resized) return null;
+        // Same upload: identical paths, or one is the other with a proxy/CDN
+        // prefix ahead of it (i0.wp.com/<host>/wp-content/... wrapping
+        // /wp-content/...). Anything else is two different images.
+        const sameAsset = a.base === b.base
+            || a.base.endsWith(b.base) || b.base.endsWith(a.base);
+        if (!sameAsset) return null;
+        const winner = a.resized ? 'b' : 'a';
+        return {
+            winner,
+            reason: 'WordPress serves the bare filename as the full-size original; the other URL is its own resized copy'
+        };
+    }
+
     getImageSizeScoreFromUrl(url) {
         if (!url || typeof url !== 'string') return -1;
 
@@ -3786,6 +3823,15 @@ class SharedCore {
                 // (winner >= 2x loser or +500) so near-ties still arbitrate,
                 // and the winner must score above the URL-length noise floor —
                 // a score that could just be a long URL decides nothing.
+                // Same upload, one of them WordPress's own resize: `flyer.jpg`
+                // and `flyer-1024x539.jpg` are ONE image, and only the
+                // derivative advertises a size — so the score rung below reads
+                // the smaller file as the bigger one and picks the thumbnail.
+                // Run 20260829-092835: THE HUNT's 2050x1080 original scored 0
+                // (a bare name claims nothing) against its own 1024x539 crop,
+                // and the crop won "clearly higher-resolution".
+                const wordPressOriginal = this.pickWordPressOriginalImage(valueA, valueB);
+                if (wordPressOriginal) return wordPressOriginal;
                 const scoreA = this.getImageSizeScoreFromUrl(String(valueA).trim());
                 const scoreB = this.getImageSizeScoreFromUrl(String(valueB).trim());
                 const winnerScore = Math.max(scoreA, scoreB);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20894,3 +20894,41 @@ test('exact-midnight starts are date-only listings — rule 11 never flags them 
   });
   assert.equal(flags.find(f => f.code === 'improbable-overnight-span'), undefined);
 });
+
+// Run 20260829-092835: THE HUNT's image merge picked the calendar's
+// The-Hunt-1024x539.jpg over the scraped 2050x1080 original and logged it as
+// "clearly higher-resolution". WordPress stores an upload as `name.ext` plus
+// resized siblings `name-WIDTHxHEIGHT.ext`, so the ONLY URL advertising a size
+// is the smaller one — the score rung cannot get this right by looking at
+// numbers.
+test('a WordPress -WxH derivative never outranks the bare original it came from', () => {
+  const core = createCore();
+  const original = 'https://bear-it.example/wp-content/uploads/2026/07/The-Hunt.jpg';
+  const derivative = 'https://bear-it.example/wp-content/uploads/2026/07/The-Hunt-1024x539.jpg';
+
+  assert.equal(core.pickWordPressOriginalImage(original, derivative).winner, 'a');
+  assert.equal(core.pickWordPressOriginalImage(derivative, original).winner, 'b');
+  // The bare original scores NOTHING on the URL size scale — which is exactly
+  // why it needs this rung ahead of the scoring one.
+  assert.ok(core.getImageSizeScoreFromUrl(derivative) > core.getImageSizeScoreFromUrl(original));
+
+  // A CDN/proxy prefix in front of the same upload is still the same upload.
+  assert.equal(core.pickWordPressOriginalImage(
+    'https://i0.wp.com/bear-it.example/wp-content/uploads/2026/07/The-Hunt.jpg?fit=2050%2C1080&ssl=1',
+    derivative
+  ).winner, 'a');
+});
+
+test('the WordPress original rung stays out of every other image contest', () => {
+  const core = createCore();
+  // Two different derivatives of one upload IS a real size comparison.
+  assert.equal(core.pickWordPressOriginalImage(
+    'https://bear-it.example/a-300x200.jpg', 'https://bear-it.example/a-1024x768.jpg'), null);
+  // Two bare names, two different images, and junk all decide nothing here.
+  assert.equal(core.pickWordPressOriginalImage(
+    'https://bear-it.example/one.jpg', 'https://bear-it.example/two.jpg'), null);
+  assert.equal(core.pickWordPressOriginalImage(
+    'https://bear-it.example/flyer.jpg', 'https://other.example/unrelated-800x600.jpg'), null);
+  assert.equal(core.pickWordPressOriginalImage('', 'https://bear-it.example/a-800x600.jpg'), null);
+  assert.equal(core.pickWordPressOriginalImage(null, null), null);
+});


### PR DESCRIPTION
An event's image was its own thumbnail, twice over

THE HUNT shipped a 1024x539 crop of a 2050x1080 flyer (run 20260828-215643).
Two independent defects had to line up, and both are generic.

1. A JSON-LD image given as an @id reference read as "no image".
   WordPress SEO plugins publish ONE @graph per page and refer between its
   nodes by @id, so bearitmtl.com's Event carries
   image: {"@id": ".../event/the-hunt/#primaryimage"} and the ImageObject that
   holds the real contentUrl — plus its published 2050x1080 — sits in the other
   script's @graph. pickJsonLdImageCandidates only understood a string or an
   object with .url, so the pointer yielded nothing and the og:image fill then
   supplied WordPress's own 1024px derivative.

   - indexJsonLdNodesById builds an @id -> node map from every ld+json script.
     RICHEST node wins, not first: the same @id appears once as the real node
     and once per reference, and references usually come first in document
     order (Yoast's WebPage points at #primaryimage above the ImageObject that
     defines it), so first-writer-wins indexed the empty pointer and resolved
     every lookup back to itself.
   - resolveJsonLdImageReference follows a pointer ONE hop, and only when the
     entry states no url of its own. contentUrl now counts as a url too — it is
     schema.org's canonical "the actual bytes" key.
   - The resolved ImageObject carries width/height, so these candidates arrive
     authoritative and the slot ranking gets real published dimensions for free.

2. Every OCR'd image measured as its DOWNSCALED self.
   Both adapters cap an OCR payload's longest side at 1024 before handing the
   bytes over, and requestAndCacheOcrResult measured those bytes — so
   The-Hunt.jpg (a real 2050x1080) and its own 1024x539 derivative BOTH recorded
   1024x539, leaving the slot ranking unable to tell an original from its
   thumbnail. The comment said "read the real shape out of the header"; by then
   the bytes were not the real shape.

   - fetchImageAsBase64 takes an optional imageMeta out-param (the convention
     callAiGenerate's diagnostics already uses) and stamps the PRE-downscale
     size. Scriptable stamps it for every image from the loaded image's own
     size; Node stamps it from the sharp metadata / sips probe it already ran.
   - The parser prefers that stamp and falls back to measuring the payload,
     which is exactly what every path did before.
   - Cached OCR entries carry the old capped numbers, so a new
     imagePixelsSource stamp marks dimensions that came from the image itself.
     Unstamped entries stay trusted UNLESS the longest side lands exactly on a
     downscale cap (1024/768) — the fingerprint of a shrunken rendition.
     Adapters with no resize capability never shrink anything, so this removes
     no information that was ever reliable, and new writes re-measure correctly.

3. A WordPress -WxH derivative outranked the original it came from.
   With 1 and 2 fixed the scrape produced the 2050x1080 original, and the merge
   still shipped the calendar's 1024x539 copy — logged as "clearly
   higher-resolution". WordPress stores an upload as `name.ext` plus resized
   siblings `name-WIDTHxHEIGHT.ext`, so the ONLY URL advertising a size is the
   smaller one: the original scores nothing on the URL size scale and loses.

   - pickWordPressOriginalImage runs ahead of the score rung. Same upload,
     exactly one carrying the resize suffix -> the bare name wins. Both bare,
     both resized, or two different uploads are not this shape and still go to
     the normal scoring. A CDN/proxy prefix in front of the same upload
     (i0.wp.com/<host>/wp-content/...) still counts as the same upload.

Verified against the live site and the real calendar (run 20260829-093331):

  before  image = .../The-Hunt-1024x539.jpg      (a crop of the real flyer)
  after   image = .../The-Hunt.jpg               2050x1080 original
          imageHorizontal = the 2050x1080 proxied form
          0 errors, 14 events

Cold-cache measurement check:

  before  The-Hunt.jpg measured 1024x539, image = The-Hunt-1024x539.jpg
  after   The-Hunt.jpg measured 2050x1080, image = the full-size original

Vignette_WEB.jpg now measures 1920x1080, Weekend-PUP 2043x1076, the site logo
32x32 — every one of them was 1024-capped or smaller before.

NOT changed: the cover prices. I reported these as reading a hidden attribute
instead of the published price; that was wrong. bearitmtl.com's own JSON-LD
publishes offers of 29 CAD (SoldOut) and 36 CAD (InStock) with an explicit
priceCurrency, and 40-50 is the separately-maintained tribe `cost` meta string.
The site contradicts itself; we follow its structured offers, which is the same
rule the Wix path already uses. No defect to fix.
