### PR TITLE
Count the programme graphics that are being read as single-event evidence

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3474,7 +3474,46 @@ class SharedCore {
             const unreadable = [imageA, imageB].filter(url => !textByUrl.has(url));
             console.log(`🖼️ MERGE: image title-evidence unavailable — no OCR text for ${unreadable.length === 2 ? 'either image' : unreadable[0]}`);
         }
+        // REPORT-ONLY census (no behavior change). A weekend/festival
+        // PROGRAMME graphic names several events, so the title-evidence rung
+        // can read it as proof for any one of them — it is sound artwork but
+        // unsound evidence. bearitmtl.com run 20260829-102510: Concours PUP
+        // Montréal's featured image is the PUP weekend schedule, whose text
+        // names "Concours Pup Montréal" AND "Kink Playground" and would have
+        // out-argued KINK's own dedicated flyer had that flyer's tokens not
+        // happened to tie it. Counting matters before enforcing anything.
+        for (const [url, text] of textByUrl) {
+            const clockTimes = this.countDistinctFlyerClockTimes(text);
+            if (clockTimes >= 3) {
+                console.log(`🖼️ MERGE: image title-evidence looks like a multi-event schedule (${clockTimes} distinct clock times) — still used this run: ${url}`);
+            }
+        }
         return textByUrl.size > 0 ? textByUrl : null;
+    }
+
+    // How many DISTINCT times of day a flyer's OCR text states. A dedicated
+    // event flyer states one or two (a doors time, or a start-end range);
+    // a programme states one per entry. Measured across the real corpus
+    // 2026-08-29: KINK Playground 1, THE HUNT 1, ENSEMBLE 2, MEAT MARKET 2,
+    // PUP weekend programme 5. Language-neutral on purpose — it reads clocks,
+    // never month names or the word "schedule".
+    countDistinctFlyerClockTimes(text) {
+        const source = String(text || '');
+        if (!source) return 0;
+        // 24-hour ("17h00", "22:00") or 12-hour with a meridiem ("9 PM", "4:30pm").
+        const pattern = /(?:\b([01]?\d|2[0-3])\s*[h:]\s*([0-5]\d)\b)|(?:\b(1[0-2]|0?\d)\s*(?:[:.]([0-5]\d))?\s*([ap])\.?m\.?\b)/gi;
+        const minutes = new Set();
+        let match;
+        while ((match = pattern.exec(source)) !== null) {
+            if (match[1] !== undefined) {
+                minutes.add((parseInt(match[1], 10) * 60) + parseInt(match[2], 10));
+                continue;
+            }
+            let hour = parseInt(match[3], 10) % 12;
+            if (String(match[5]).toLowerCase() === 'p') hour += 12;
+            minutes.add((hour * 60) + (match[4] ? parseInt(match[4], 10) : 0));
+        }
+        return minutes.size;
     }
 
     resolveConflictDeterministically(fieldName, valueA, valueB, context = null) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20932,3 +20932,34 @@ test('the WordPress original rung stays out of every other image contest', () =>
   assert.equal(core.pickWordPressOriginalImage('', 'https://bear-it.example/a-800x600.jpg'), null);
   assert.equal(core.pickWordPressOriginalImage(null, null), null);
 });
+
+// Report-only census for multi-event PROGRAMME graphics. bearitmtl.com uses the
+// PUP weekend schedule as Concours PUP Montréal's featured image (run
+// 20260829-102510): sound artwork, unsound EVIDENCE, because its text names
+// "Concours Pup Montréal" AND "Kink Playground" and the title-evidence rung
+// reads whichever event it is asked about. Counting clocks separates a
+// programme from a flyer without reading month names or the word "schedule".
+test('countDistinctFlyerClockTimes separates a programme from a real flyer', () => {
+  const core = createCore();
+  const programme = 'Programmation 2026 31 juillet - July 31st 17h00 : Ouverture du concours '
+    + '21h30 : Unleashed par WoofMTL 1 août - August 1st 18h00 : Concours Pup Montréal '
+    + '22h00 : Kink Playground par Bear It 2 août - August 2nd 13h00 : Diner de clôture';
+  assert.equal(core.countDistinctFlyerClockTimes(programme), 5);
+
+  // Every real single-event flyer in the corpus states one or two times.
+  assert.equal(core.countDistinctFlyerClockTimes(
+    'KINK PLAYGROUND 1ER AOUT 2026 AU BAIN MATHIEU OUVERTURE DES PORTES À 22:00'), 1);
+  assert.equal(core.countDistinctFlyerClockTimes(
+    'THE HUNT 6 SEPTEMBRE 2026 · 9 PM DRESS CODE ENCOURAGED'), 1);
+  assert.equal(core.countDistinctFlyerClockTimes(
+    'ENSEMBLE STOCK AND SODA, SAMEDI 19 SEPTEMBRE 2026 - MEET AND GREET 18:00 - 20:00 SPECTACLE'), 2);
+  assert.equal(core.countDistinctFlyerClockTimes(
+    'CLUB CHUB PRESENTS MEAT MARKET SATURDAY NOVEMBER 1 4PM - 9PM'), 2);
+
+  // The same clock written twice is one time, not two.
+  assert.equal(core.countDistinctFlyerClockTimes('doors 22:00, music 22h00'), 1);
+  assert.equal(core.countDistinctFlyerClockTimes(''), 0);
+  assert.equal(core.countDistinctFlyerClockTimes(null), 0);
+  // A year is not a clock.
+  assert.equal(core.countDistinctFlyerClockTimes('SUMMER 2026 BEAR WEEK'), 0);
+});


### PR DESCRIPTION
Count the programme graphics that are being read as single-event evidence

Concours PUP Montréal's image is bearitmtl.com's PUP WEEKEND programme — a
schedule graphic listing five things across three days:

  31 juillet  17h00 Ouverture du concours / 21h30 Unleashed par WoofMTL
  1 août      18h00 Concours Pup Montréal / 22h00 Kink Playground par Bear It
  2 août      13h00 Diner de clôture

Nothing is wrong with the event: it is 18:00-21:00 on Aug 1, which matches both
the site's structured data and the flyer's own line for it. And the image is the
site's own featured image for that event, carried faithfully.

The problem is that this graphic is sound ARTWORK and unsound EVIDENCE. The OCR
title-evidence rung asks "does this flyer name the event's title?", and a
programme names every event on it, so it answers yes for all of them. Checked
against the live texts:

  event "KINK Playground"       own flyer -> kink, playground
                                programme -> kink, playground     (exclusive: none, ties)
  event "Concours PUP Montréal" own flyer -> none
                                programme -> concours, pup        (exclusive: 2, decides)

KINK survives only because its own flyer happens to match the same two tokens.
Had the title differed slightly, or had its flyer been unreadable, the weekend
programme would have out-argued a real dedicated flyer with two exclusive tokens.

Report-only, no behavior change. countDistinctFlyerClockTimes reads how many
distinct times of day a flyer's text states — language-neutral, it reads clocks
and never month names or the word "schedule". The corpus separates cleanly:

  KINK Playground own flyer   1        THE HUNT flyer      1
  ENSEMBLE flyer              2        MEAT MARKET flyer   2
  PUP weekend programme       5

A dedicated flyer states a doors time or a start-end range; a programme states
one per entry. preloadImageOcrTextEvidence now logs when evidence it is about to
serve looks like a programme (>= 3 distinct clock times) and still serves it, so
a corpus run can count how often this shape appears before anything is enforced.

First census (runs 20260829-103111 / 103112): 10 log lines, ALL of them the same
PUP programme in its two URL forms, and ZERO title-evidence decisions made from
it — the tie above. Club Chub produced no hits at all; its flyers are real
single-event artwork. Bear it MTL still yields the same 14 events, Club Chub the
same 3, 0 errors on both.

The enforce step, if the census stays this quiet, is to withhold a programme
from the evidence map — the rung then sees an unreadable side and falls through
to the rungs it used before #1711, which is already its documented fail-open
path. Not doing that yet on one site's worth of data.
