### PR TITLE
Withhold programme graphics from single-event title evidence

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -31,6 +31,10 @@ const ADAPTIVE_CRAWL_MAX_HOPS = 4;
 // sub-km disagreement is meaningful. Shared by the merge-time STEP 3c flag
 // and the calendar reviewer's pin-moved check.
 const PIN_MOVED_THRESHOLD_KM = 0.4;
+// Distinct clock times at which a flyer's OCR text stops being one event's
+// artwork and starts being a programme — see countDistinctFlyerClockTimes for
+// the corpus census that picked 4.
+const MULTI_EVENT_SCHEDULE_CLOCK_TIMES = 4;
 
 // New-venue-candidate detection (gathering-only growth loop): barSource
 // stamps that positively corroborate an extracted bar name without meaning
@@ -3460,7 +3464,22 @@ class SharedCore {
                 // the persistent cache answers forever. OCR is local-model
                 // work; the owner's standing doctrine is to spend it.
                 const text = await this.ocrImageTextLookup(url, httpAdapter);
-                if (typeof text === 'string' && text.trim()) textByUrl.set(url, text);
+                if (typeof text === 'string' && text.trim()) {
+                    // A weekend/festival PROGRAMME names every event on it, so
+                    // it answers "does this flyer name the event?" with yes for
+                    // all of them — sound artwork, unsound evidence. Withhold
+                    // it: the rung requires BOTH texts, so this falls through
+                    // to the URL rungs exactly like an unreadable image, which
+                    // is its documented fail-open path. The image itself is
+                    // untouched — a site is free to use a schedule as an
+                    // event's artwork, and bearitmtl.com does.
+                    const clockTimes = this.countDistinctFlyerClockTimes(text);
+                    if (clockTimes >= MULTI_EVENT_SCHEDULE_CLOCK_TIMES) {
+                        console.log(`🖼️ MERGE: image withheld from title-evidence — reads as a multi-event schedule (${clockTimes} distinct clock times): ${url}`);
+                        continue;
+                    }
+                    textByUrl.set(url, text);
+                }
             } catch (_) {
                 // Unreadable side: the rung requires both texts, so this
                 // lookup failure falls through to existing behavior.
@@ -3474,29 +3493,31 @@ class SharedCore {
             const unreadable = [imageA, imageB].filter(url => !textByUrl.has(url));
             console.log(`🖼️ MERGE: image title-evidence unavailable — no OCR text for ${unreadable.length === 2 ? 'either image' : unreadable[0]}`);
         }
-        // REPORT-ONLY census (no behavior change). A weekend/festival
-        // PROGRAMME graphic names several events, so the title-evidence rung
-        // can read it as proof for any one of them — it is sound artwork but
-        // unsound evidence. bearitmtl.com run 20260829-102510: Concours PUP
-        // Montréal's featured image is the PUP weekend schedule, whose text
-        // names "Concours Pup Montréal" AND "Kink Playground" and would have
-        // out-argued KINK's own dedicated flyer had that flyer's tokens not
-        // happened to tie it. Counting matters before enforcing anything.
-        for (const [url, text] of textByUrl) {
-            const clockTimes = this.countDistinctFlyerClockTimes(text);
-            if (clockTimes >= 3) {
-                console.log(`🖼️ MERGE: image title-evidence looks like a multi-event schedule (${clockTimes} distinct clock times) — still used this run: ${url}`);
-            }
-        }
         return textByUrl.size > 0 ? textByUrl : null;
     }
 
     // How many DISTINCT times of day a flyer's OCR text states. A dedicated
     // event flyer states one or two (a doors time, or a start-end range);
-    // a programme states one per entry. Measured across the real corpus
-    // 2026-08-29: KINK Playground 1, THE HUNT 1, ENSEMBLE 2, MEAT MARKET 2,
-    // PUP weekend programme 5. Language-neutral on purpose — it reads clocks,
-    // never month names or the word "schedule".
+    // a programme states one per entry. Language-neutral on purpose — it reads
+    // clocks, never month names or the word "schedule".
+    //
+    // Threshold picked from the census, not from taste. Scanning all 669
+    // readable flyers in the OCR cache (2026-08-29) gave a clean break at 4:
+    //   0-2 times  654 flyers  ordinary single-event artwork
+    //     3 times    4 flyers  ALL false positives — real single events that
+    //                          happen to print three clocks (Eagle LA "Dads &
+    //                          Lads" @9pm with sock auctions 10:30pm/11:30pm;
+    //                          "Gutter Club (K)night" 7PM-12AM, doors 7:00PM,
+    //                          fighting 8-11:00; Bearracuda "Hot Take")
+    //    4+ times   11 flyers  ALL genuine programmes (Lumber Yard's weekly
+    //                          bar listing x4, BeefDip "Bear Week Schedule",
+    //                          Northeast Ursamen "Out of Hibernation
+    //                          Schedule", Eagle LA's Mx. Cruise Leather
+    //                          weekend, the PUP weekend programme x4 URLs)
+    // Three was one notch too eager. The OCR model's own imageClassification
+    // is NOT a usable gate here: it labelled only 4 of those 11 as
+    // multi-event-flyer and called BeefDip's Bear Week Schedule an
+    // "event-flyer".
     countDistinctFlyerClockTimes(text) {
         const source = String(text || '');
         if (!source) return 0;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20939,6 +20939,32 @@ test('the WordPress original rung stays out of every other image contest', () =>
 // "Concours Pup Montréal" AND "Kink Playground" and the title-evidence rung
 // reads whichever event it is asked about. Counting clocks separates a
 // programme from a flyer without reading month names or the word "schedule".
+test('the programme guard withholds a schedule from title evidence, and only a schedule', async () => {
+  const core = createCore();
+  const programme = 'Programmation 2026 31 juillet 17h00 : Ouverture du concours 21h30 : Unleashed '
+    + '1 aout 18h00 : Concours Pup Montreal 22h00 : Kink Playground 2 aout 13h00 : Diner de cloture';
+  const realFlyer = 'KINK PLAYGROUND 1ER AOUT 2026 AU BAIN MATHIEU OUVERTURE DES PORTES A 22:00';
+  // Three clocks on ONE event is the shape the census proved is a false
+  // positive (Eagle LA's Dads & Lads), so it must still serve as evidence.
+  const threeClockFlyer = 'Dads & Lads Eagle LA Friday August 21 @ 9pm Sock Auction 10:30pm & 11:30pm';
+
+  const texts = {
+    'https://site.example/programme.jpg': programme,
+    'https://site.example/kink.jpg': realFlyer,
+    'https://site.example/dads.jpg': threeClockFlyer
+  };
+  core.setOcrImageTextLookup(async (url) => texts[url] || '');
+
+  const withheld = await core.preloadImageOcrTextEvidence(
+    { image: 'https://site.example/programme.jpg' }, { image: 'https://site.example/kink.jpg' });
+  assert.equal(withheld.size, 1, 'the programme is withheld; the real flyer stays');
+  assert.equal(withheld.has('https://site.example/programme.jpg'), false);
+
+  const kept = await core.preloadImageOcrTextEvidence(
+    { image: 'https://site.example/dads.jpg' }, { image: 'https://site.example/kink.jpg' });
+  assert.equal(kept.size, 2, 'a three-clock single-event flyer is NOT a programme');
+});
+
 test('countDistinctFlyerClockTimes separates a programme from a real flyer', () => {
   const core = createCore();
   const programme = 'Programmation 2026 31 juillet - July 31st 17h00 : Ouverture du concours '


### PR DESCRIPTION
Withhold programme graphics from single-event title evidence (threshold from the census)

The report-only census from #1715 has its answer, and it moved the threshold.

Scanning all 669 readable flyers in the OCR cache gave a clean break at FOUR
distinct clock times, not three:

  0-2 times   654 flyers   ordinary single-event artwork
    3 times     4 flyers   ALL false positives — real single events that happen
                           to print three clocks: Eagle LA "Dads & Lads" @9pm
                           with sock auctions at 10:30pm and 11:30pm; "Gutter
                           Club (K)night" 7PM-12AM with doors 7:00PM and
                           fighting 8-11:00 (x2 cached URLs); Bearracuda
                           "Hot Take" with a meet-and-greet time
   4+ times    11 flyers   ALL genuine programmes — Lumber Yard's weekly bar
                           listing (x4), BeefDip "Bear Week Schedule",
                           Northeast Ursamen "Out of Hibernation Schedule",
                           Eagle LA's multi-day Mx. Cruise Leather weekend, and
                           the PUP weekend programme (x4 URL variants)

Three was one notch too eager. Four is exact on this corpus: 11 true, 0 false.

Worth recording: the OCR model's own imageClassification is NOT a usable gate
here. It labelled only 4 of those 11 as multi-event-flyer and called BeefDip's
"Bear Week Schedule" an event-flyer, so the clock count is doing the work.

Enforcement is deliberately the smallest possible move: a programme is withheld
from the evidence map rather than judged. The rung requires BOTH texts, so a
withheld side falls through to the URL rungs exactly like an unreadable image —
its already-documented fail-open path. The IMAGE is untouched: a site may use a
schedule as an event's artwork, and bearitmtl.com does.

Measured before flipping, on the pre-enforcement full run 20260829-110754: the
only programme that ever reached the evidence path was the PUP graphic, and it
decided nothing (its tokens tie against KINK Playground's own flyer). So the
expected behavioral delta was zero, and that is what happened.

Verified per parser, enforced vs that full run:

  Bear it MTL     14 -> 14    Club Chub    3 -> 3
  BeefDip         34 -> 34    Eagle LA    16 -> 16
  none added, none removed on any of them

  withheld:  10 lines, every one the PUP programme in its two URL forms
  preserved: all 4 legitimate title-evidence decisions still fire —
             "bear la cub 2027 contest", "bear la cub", "beefdip bear week",
             "wild trek atv tours"

So this removes a latent hazard without moving today's output: a programme can
no longer out-argue a real dedicated flyer for an event it merely lists.
