### PR TITLE
Read the calendar Rockbar actually publishes, and stop a stale page dating itself forward

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1078,6 +1078,18 @@ class AiWebParser {
             // returned grids join URL discovery as additional sources (links
             // only — the grid HTML never segments). Non-MEC pages, adapters
             // without postForm and lookahead 0 all no-op here.
+            // Client-side calendar widgets: the events exist, just not in the
+            // HTML. Read them deterministically before anything else runs, so
+            // a page that would otherwise look empty is not handed to the AI
+            // as an empty page. Sites without the widget no-op here.
+            const elfsightRows = await this.collectElfsightCalendarEvents(effectiveHtmlData, parserConfig, httpAdapter);
+            const elfsightEvents = elfsightRows
+                .map(row => this.buildEventFromElfsightRow(row, sourceUrl))
+                .filter(Boolean);
+            if (elfsightRows.length > 0) {
+                const recurring = elfsightEvents.filter(event => event.recurrenceRule).length;
+                console.log(`🗓️ ELFSIGHT: built ${elfsightEvents.length} event(s) from ${elfsightRows.length} widget row(s) for ${sourceUrl} (${recurring} recurring → ICS export, never a calendar series)`);
+            }
             const monthFeedSources = await this.collectMecMonthFeeds(effectiveHtmlData, parserConfig, httpAdapter);
             const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig, monthFeedSources);
             if (monthFeedSources.length > 0) {
@@ -1125,10 +1137,19 @@ class AiWebParser {
                 ? this.extractEventsFromJsonApiPayload(jsonApiPayload, sourceUrl, cityConfig)
                 : [];
             const completeJsonApiEvents = jsonApiEvents.filter(event => event.bar || event.address);
+            // Elfsight rows carry no venue of their own — the widget IS the
+            // venue's own calendar on the venue's own page, so bar/address come
+            // from the site the same way they do for any venue-role parser.
+            // That is why they skip the bar||address completeness gate the two
+            // sources above apply to third-party structured data.
             const structuredSource = completeJsonLdEvents.length > 0
                 ? 'jsonld'
-                : (completeJsonApiEvents.length > 0 ? 'json-api' : null);
-            const structuredEvents = structuredSource === 'jsonld' ? completeJsonLdEvents : completeJsonApiEvents;
+                : (completeJsonApiEvents.length > 0
+                    ? 'json-api'
+                    : (elfsightEvents.length > 0 ? 'elfsight' : null));
+            const structuredEvents = structuredSource === 'jsonld'
+                ? completeJsonLdEvents
+                : (structuredSource === 'json-api' ? completeJsonApiEvents : elfsightEvents);
             const useStructuredEvents = parserConfig.discoveryOnly !== true
                 && pageClassification !== 'link-aggregator'
                 && structuredEvents.length > 0
@@ -1140,7 +1161,9 @@ class AiWebParser {
                 // all; the events' own artwork is OCR'd below, so the line
                 // now names what is actually skipped (the ocr-all sweep and
                 // the AI extraction passes).
-                if (structuredSource === 'json-api') {
+                if (structuredSource === 'elfsight') {
+                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from the Elfsight calendar widget — skipping the OCR sweep and AI extraction (event artwork is still read)`);
+                } else if (structuredSource === 'json-api') {
                     console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON API structured data — skipping the OCR sweep and AI extraction (event artwork is still read)`);
                 } else {
                     console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON-LD structured data — skipping the OCR sweep and AI extraction (event artwork is still read)`);
@@ -5133,6 +5156,186 @@ class AiWebParser {
      * fragments) so repeat runs inside the TTL replay the same grid without
      * touching the network.
      */
+    // Elfsight Event Calendar widgets render entirely client-side, so the page
+    // HTML carries nothing but a placeholder div — a crawl that only reads HTML
+    // sees an empty calendar and concludes the venue posts nothing. Rockbar's
+    // /calendar is exactly this: the site's own nav points at it, the browser
+    // shows a full season, and our fetch saw zero events while we scraped a
+    // stale /events archive from 2024 instead.
+    //
+    // The widget boots from ONE public GET that returns every event with exact
+    // dates, times, an IANA timezone, artwork and real recurrence fields — no
+    // browser, no rendering. Generic by construction: the widget id comes from
+    // the page's own markup and the host is Elfsight's fixed service endpoint,
+    // so any site embedding this widget is read the same way.
+    async collectElfsightCalendarEvents(htmlData, parserConfig, httpAdapter) {
+        const html = htmlData && htmlData.html ? htmlData.html : '';
+        const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
+        if (!html || !httpAdapter || typeof httpAdapter.fetchData !== 'function') return [];
+        const widgetIds = this.extractElfsightWidgetIds(html);
+        if (widgetIds.length === 0) return [];
+        // The embed usually sits in a shared block, so EVERY page of the site
+        // carries the same widget and would re-publish the same full calendar.
+        // Read it only on the page the parser was pointed at: one read per
+        // crawl, and the events keep the URL the config chose for them.
+        // (Rockbar's first attempt built 150 events on /calendar and another
+        // 150 on the homepage before the run ran out of time merging them.)
+        if (!this.isConfiguredParserUrl(sourceUrl, parserConfig)) {
+            console.log(`🗓️ ELFSIGHT: widget present on ${sourceUrl} but this is not the configured entry page — already read there, skipping`);
+            return [];
+        }
+
+        const events = [];
+        for (const widgetId of widgetIds) {
+            const bootUrl = `https://core.service.elfsight.com/p/boot/?w=${widgetId}`;
+            let payload = null;
+            try {
+                const response = await httpAdapter.fetchData(bootUrl, { headers: { Referer: sourceUrl } });
+                const body = response && typeof response.html === 'string'
+                    ? response.html
+                    : (typeof response === 'string' ? response : '');
+                payload = body ? JSON.parse(body) : null;
+            } catch (error) {
+                console.warn(`🤖 AI Web: Elfsight widget ${widgetId} could not be read (${error.message}) — page left unchanged`);
+                continue;
+            }
+            const rows = this.readElfsightWidgetEvents(payload, widgetId);
+            if (rows.length === 0) continue;
+            console.log(`🗓️ ELFSIGHT: widget ${widgetId} on ${sourceUrl} published ${rows.length} event(s)`);
+            events.push(...rows);
+        }
+        return events;
+    }
+
+    // Is this URL one the parser was configured to fetch? Compared on the
+    // dedupe key so a trailing slash or a tracking param does not disqualify
+    // the page the config actually named.
+    isConfiguredParserUrl(url, parserConfig) {
+        const configured = parserConfig && Array.isArray(parserConfig.urls) ? parserConfig.urls : [];
+        if (configured.length === 0) return false;
+        const key = this.getUrlDedupeKey(this.stripTrackingParams(String(url || '')));
+        if (!key) return false;
+        return configured.some(candidate => this.getUrlDedupeKey(this.stripTrackingParams(String(candidate || ''))) === key);
+    }
+
+    // Widget ids as the embed markup writes them: class="elfsight-app-<uuid>".
+    extractElfsightWidgetIds(html) {
+        const ids = new Set();
+        const pattern = /elfsight-app-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
+        let match;
+        while ((match = pattern.exec(String(html || ''))) !== null) ids.add(match[1].toLowerCase());
+        return Array.from(ids);
+    }
+
+    // The boot payload nests the settings under the widget's own id. Anything
+    // absent or oddly shaped yields [] — never a partial guess.
+    readElfsightWidgetEvents(payload, widgetId) {
+        const widgets = payload && payload.data && payload.data.widgets;
+        const widget = widgets && typeof widgets === 'object' ? widgets[widgetId] : null;
+        const settings = widget && widget.data && widget.data.settings;
+        const rows = settings && Array.isArray(settings.events) ? settings.events : [];
+        return rows.filter(row => row && typeof row === 'object' && row.visible !== false && row.name);
+    }
+
+    // One Elfsight row -> one parser event, built deterministically (no AI, no
+    // OCR) the way extractEventsFromJsonLd builds from structured data.
+    // A recurring row keeps its recurrence as an RRULE, which is what routes it
+    // to the ICS-export path and away from calendar writes — the scraper still
+    // never writes a series. A row whose repeat shape has no honest RRULE is
+    // emitted as its stated single date rather than guessed at.
+    buildEventFromElfsightRow(row, sourceUrl) {
+        const start = row.start && typeof row.start === 'object' ? row.start : {};
+        const end = row.end && typeof row.end === 'object' ? row.end : {};
+        if (!start.date) return null;
+        const timezone = typeof row.timeZone === 'string' && row.timeZone.trim() ? row.timeZone.trim() : '';
+        const startDate = this.convertLocalDateTimeToUtc(`${start.date} ${start.time || '00:00'}:00`, timezone)
+            || combineDateAndTime(start.date, start.time || '00:00');
+        if (!(startDate instanceof Date) || Number.isNaN(startDate.getTime())) return null;
+        let endDate = end.date
+            ? (this.convertLocalDateTimeToUtc(`${end.date} ${end.time || start.time || '00:00'}:00`, timezone)
+                || combineDateAndTime(end.date, end.time || start.time || '00:00'))
+            : null;
+        if (endDate instanceof Date && endDate.getTime() < startDate.getTime()) {
+            endDate = new Date(endDate.getTime() + (24 * 60 * 60 * 1000));
+        }
+        const description = this.normalizeWhitespace(
+            this.decodeBasicEntities(this.stripTags(String(row.description || ''))).replace(/&amp;/gi, '&')
+        );
+        const event = {
+            title: this.normalizeWhitespace(String(row.name || '')),
+            description,
+            startDate,
+            endDate: endDate || null,
+            timezone: timezone || null,
+            url: sourceUrl,
+            website: sourceUrl,
+            source: 'elfsight'
+        };
+        const image = this.pickElfsightImage(row);
+        if (image) event.image = image;
+        const rrule = this.buildElfsightRecurrenceRule(row, startDate, timezone);
+        if (rrule) event.recurrenceRule = rrule;
+        return event;
+    }
+
+    pickElfsightImage(row) {
+        const candidates = [row.coverImage, Array.isArray(row.images) ? row.images[0] : null];
+        for (const candidate of candidates) {
+            const raw = typeof candidate === 'string'
+                ? candidate
+                : (candidate && typeof candidate === 'object' ? (candidate.url || candidate.src || '') : '');
+            const normalized = this.normalizeHttpUrlValue(String(raw || '').trim());
+            if (normalized) return normalized;
+        }
+        return '';
+    }
+
+    // Elfsight's repeat shapes -> RRULE. Only the shapes that map exactly are
+    // translated; `custom` and anything unrecognized return null so the row
+    // ships as a single dated event instead of a fabricated series.
+    buildElfsightRecurrenceRule(row, startDate, timezone) {
+        const period = String(row.repeatPeriod || '').trim();
+        const dayCodes = { su: 'SU', mo: 'MO', tu: 'TU', we: 'WE', th: 'TH', fr: 'FR', sa: 'SA' };
+        const localWeekday = () => {
+            const parts = this.getElfsightLocalDateParts(startDate, timezone);
+            return parts ? ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'][parts.weekday] : null;
+        };
+        if (period === 'weeklyOn') {
+            const days = Array.isArray(row.repeatWeeklyOnDays)
+                ? row.repeatWeeklyOnDays.map(day => dayCodes[String(day).toLowerCase()]).filter(Boolean)
+                : [];
+            const byDay = days.length > 0 ? days : [localWeekday()].filter(Boolean);
+            if (byDay.length === 0) return null;
+            return `FREQ=WEEKLY;BYDAY=${byDay.join(',')}`;
+        }
+        if (period === 'lastDayInMonth') {
+            const day = localWeekday();
+            return day ? `FREQ=MONTHLY;BYDAY=-1${day}` : null;
+        }
+        if (period === 'nthDayInMonth') {
+            const parts = this.getElfsightLocalDateParts(startDate, timezone);
+            const day = localWeekday();
+            if (!parts || !day) return null;
+            const ordinal = Math.floor((parts.dayOfMonth - 1) / 7) + 1;
+            return `FREQ=MONTHLY;BYDAY=${ordinal}${day}`;
+        }
+        return null;
+    }
+
+    // Local weekday + day-of-month for an instant, in the row's own timezone.
+    getElfsightLocalDateParts(date, timezone) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
+        if (!timezone) {
+            return { weekday: date.getUTCDay(), dayOfMonth: date.getUTCDate() };
+        }
+        const offsetMinutes = this.core && typeof this.core.getTimezoneOffsetMinutes === 'function'
+            ? this.core.getTimezoneOffsetMinutes(date, timezone)
+            : null;
+        if (!Number.isFinite(offsetMinutes)) return null;
+        const local = new Date(date.getTime() + (offsetMinutes * 60 * 1000));
+        return { weekday: local.getUTCDay(), dayOfMonth: local.getUTCDate() };
+    }
+
     async collectMecMonthFeeds(htmlData, parserConfig, httpAdapter) {
         const html = htmlData && htmlData.html ? htmlData.html : '';
         const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
@@ -13522,7 +13725,11 @@ TEXT:
                         // and nowhere downstream. Resolved against the
                         // post-pin value so a weekday pin, which is itself
                         // deterministic, stays the authority when it fired.
-                        const explicitYear = this.resolveExplicitSourceYear(value, fieldData.evidence, confidence);
+                        // `snippet` rides along for the same reason the pin
+                        // above takes it: when the model quotes a shorter
+                        // evidence string than the page actually shows, the
+                        // page is still the authority.
+                        const explicitYear = this.resolveExplicitSourceYear(value, fieldData.evidence, confidence, snippet);
                         if (explicitYear !== null) {
                             if (!filteredEvent.__explicitSourceYears || typeof filteredEvent.__explicitSourceYears !== 'object') {
                                 filteredEvent.__explicitSourceYears = {};
@@ -17257,21 +17464,68 @@ TEXT:
     //     string — the anti-hallucination gate's own standard. A year the
     //     model invented cannot pass this; only one printed on the page can.
     // Returns the year number, or null when the year stays repairable.
-    resolveExplicitSourceYear(value, evidence, confidence) {
-        const minConfidence = this.extractionLimits && typeof this.extractionLimits.explicitSourceYearMinConfidence === 'number'
-            ? this.extractionLimits.explicitSourceYearMinConfidence
-            : 90;
-        if (typeof confidence !== 'number' || !Number.isFinite(confidence) || confidence < minConfidence) return null;
-
+    resolveExplicitSourceYear(value, evidence, confidence, sourceText = '') {
         const rawValue = String(value === null || value === undefined ? '' : value);
         const valueYearMatch = rawValue.match(/(?:19|20)\d{2}/);
         if (!valueYearMatch) return null;
-
-        const evidenceText = String(evidence || '');
-        if (!evidenceText || !evidenceText.includes(valueYearMatch[0])) return null;
-
         const year = Number(valueYearMatch[0]);
-        return Number.isFinite(year) ? year : null;
+        if (!Number.isFinite(year)) return null;
+
+        const minConfidence = this.extractionLimits && typeof this.extractionLimits.explicitSourceYearMinConfidence === 'number'
+            ? this.extractionLimits.explicitSourceYearMinConfidence
+            : 90;
+        const confidentEnough = typeof confidence === 'number' && Number.isFinite(confidence) && confidence >= minConfidence;
+        const evidenceText = String(evidence || '');
+        if (confidentEnough && evidenceText && evidenceText.includes(valueYearMatch[0])) return year;
+
+        // The model's quoted snippet is not the only witness. Rockbar run
+        // 20260829-110754: six passes read BEARS NIGHT OUT's date; four quoted
+        // "Saturday, August 3, 2024" at confidence 100, but the pass that won
+        // cited "og:image filename: Bears-Night-Out-Aug-3.jpg" at confidence
+        // 80 — no year, under the floor — so 2024 counted as a guess and the
+        // window repair walked a two-year-old archive forward to 2026. The
+        // page said 2024 the whole time. When the SOURCE states this value's
+        // own year beside its own month and day, that is stated fact no matter
+        // which pass won or how sure it claimed to be.
+        if (this.sourceStatesValueYear(rawValue, sourceText)) return year;
+        return null;
+    }
+
+    // Does `sourceText` state the year of `value` right next to value's own
+    // month and day? Deliberately narrow: a bare year elsewhere on the page (a
+    // copyright line, an "est. 2006") must never pin an event's year, so the
+    // year has to sit within a short span of the matching day and month.
+    // Accepts the ISO spelling and the common written orders.
+    sourceStatesValueYear(value, sourceText) {
+        const text = String(sourceText || '');
+        if (!text) return false;
+        const match = String(value || '').match(/((?:19|20)\d{2})-(\d{2})-(\d{2})/);
+        if (!match) return false;
+        const [, year, month, day] = match;
+        // Deliberately NOT matching the ISO spelling. Sites name flyer files
+        // by date and reuse last year's files on this year's page:
+        // beefdip.com/wp-content/uploads/2026/01/"2026-01-25 Welcome Party.webp"
+        // sits beside visible copy reading "MONDAY JANUARY 25, 2027". Counting
+        // that filename as a stated year marked eight real 2027 events as
+        // archived 2026 ones and dropped them — the very failure this guard
+        // exists to prevent, arriving through the very same door (a date read
+        // off an image filename). Only prose the page shows a reader counts.
+
+        const monthNames = ['january', 'february', 'march', 'april', 'may', 'june',
+            'july', 'august', 'september', 'october', 'november', 'december'];
+        const name = monthNames[parseInt(month, 10) - 1];
+        if (!name) return false;
+        const monthPattern = `${name.slice(0, 3)}(?:${name.slice(3)})?\\.?`;
+        const dayPattern = `0?${parseInt(day, 10)}(?:st|nd|rd|th)?`;
+        // "August 3, 2024" / "Aug 3 2024" and the day-first "3 August 2024".
+        // Only a comma and whitespace may sit between the day and the year:
+        // anything richer is a different sentence, and a page footer's
+        // "(c) 2024" must never pin an event that merely mentions a day.
+        const orders = [
+            new RegExp(`${monthPattern}\\s+${dayPattern}\\b[,\\s]{0,4}${year}`, 'i'),
+            new RegExp(`\\b${dayPattern}\\s+${monthPattern}[,\\s]{0,4}${year}`, 'i')
+        ];
+        return orders.some(pattern => pattern.test(text));
     }
 
     // True when `date` still carries the explicitly stated year (so skipping

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -16029,3 +16029,183 @@ test('an adapter that reports its pre-downscale size beats measuring the shrunke
   assert.equal(parser.pickTrueImageDimensions({ originalWidth: 0, originalHeight: 10 }), null);
   assert.equal(parser.pickTrueImageDimensions(null), null);
 });
+
+// ---------------------------------------------------------------------------
+// Explicit source years corroborated against the page, not only the model's
+// quoted snippet. Rockbar run 20260829-110754: six passes read BEARS NIGHT
+// OUT's date; four quoted "Saturday, August 3, 2024" at confidence 100, but
+// the pass that WON cited the og:image filename at confidence 80 — no year,
+// under the floor — so 2024 counted as a guess and the window repair walked a
+// two-year-old archive forward to 2026.
+// ---------------------------------------------------------------------------
+
+const ROCKBAR_PAGE_TEXT = 'Back to All Events BEARS NIGHT OUT Saturday, August 3, 2024 '
+  + '9:00 PM 9:00 PM Google Calendar ICS HOSTED BY THE URBAN BEAR DJ STEVEN CUNNINGHAM';
+
+test('a year the page states is explicit even when the model quoted a shorter snippet', () => {
+  const parser = createParser();
+  // The exact losing pass, with and without the page text behind it.
+  assert.equal(parser.resolveExplicitSourceYear(
+    '2024-08-03', 'og:image filename: Bears-Night-Out-Aug-3.jpg', 80, ROCKBAR_PAGE_TEXT), 2024);
+  assert.equal(parser.resolveExplicitSourceYear(
+    '2024-08-03', 'og:image filename: Bears-Night-Out-Aug-3.jpg', 80, ''), null);
+  // The original quoted-evidence path is untouched.
+  assert.equal(parser.resolveExplicitSourceYear('2024-08-03', 'Saturday, August 3, 2024', 100, ''), 2024);
+  // A value with no year of its own still resolves to nothing.
+  assert.equal(parser.resolveExplicitSourceYear('08-03', 'August 3', 100, ROCKBAR_PAGE_TEXT), null);
+});
+
+test('page corroboration wants the year beside the date, not merely on the page', () => {
+  const parser = createParser();
+  const near = (text) => parser.sourceStatesValueYear('2024-08-03', text);
+  assert.equal(near('Saturday, August 3, 2024'), true);
+  assert.equal(near('August 3rd, 2024'), true);
+  assert.equal(near('3 August 2024'), true);
+  assert.equal(near('Aug 3 2024'), true);
+  // The ISO spelling deliberately does NOT count: sites name flyer files by
+  // date and reuse last year's files, so "…/2026-01-25 Welcome Party.webp" sat
+  // beside visible copy reading "MONDAY JANUARY 25, 2027" on beefdip.com and
+  // would have marked eight real 2027 events as archived 2026 ones.
+  assert.equal(near('DTSTART 2024-08-03T21:00'), false);
+  assert.equal(
+    parser.sourceStatesValueYear('2026-01-25',
+      'MONDAY JANUARY 25, 2027 FOAM POOL PARTY … uploads/2026/01/2026-01-25 Welcome Party.webp'),
+    false, 'a flyer filename is not the page stating a year');
+  assert.equal(
+    parser.sourceStatesValueYear('2027-01-25',
+      'MONDAY JANUARY 25, 2027 FOAM POOL PARTY'),
+    true, 'the year the reader actually sees still counts');
+  // A year that belongs to something else must never pin the event.
+  assert.equal(near('BEARS NIGHT OUT August 3 · (c) 2024 Rockbar'), false);
+  assert.equal(near('August 3 ... lots of unrelated text ... Copyright 2024'), false);
+  assert.equal(near('Saturday, August 10, 2024'), false, 'different day');
+  assert.equal(near('Established 2024 · every August'), false);
+  assert.equal(near(''), false);
+});
+
+// ---------------------------------------------------------------------------
+// Elfsight calendar widgets. Rockbar's /calendar renders client-side, so the
+// HTML carries a placeholder and nothing else — the crawl saw an empty page
+// while the browser showed a full season. The widget boots from one public GET.
+// ---------------------------------------------------------------------------
+
+const ELFSIGHT_WIDGET_ID = 'e122bc50-bc4f-4cde-a6b9-ee6d4e31531a';
+const ELFSIGHT_HTML = `<html><body>
+  <div class="elfsight-app-${ELFSIGHT_WIDGET_ID}" data-elfsight-app-lazy></div>
+  <div class="elfsight-app-${ELFSIGHT_WIDGET_ID}"></div>
+</body></html>`;
+
+function elfsightBootPayload(events) {
+  return JSON.stringify({ data: { widgets: { [ELFSIGHT_WIDGET_ID]: { data: { settings: { events } } } } } });
+}
+
+test('extractElfsightWidgetIds reads each widget once', () => {
+  const parser = createParser();
+  assert.deepEqual(parser.extractElfsightWidgetIds(ELFSIGHT_HTML), [ELFSIGHT_WIDGET_ID]);
+  assert.deepEqual(parser.extractElfsightWidgetIds('<div>no widget</div>'), []);
+});
+
+test('an Elfsight row becomes an event with its own timezone, and recurrence becomes an RRULE', () => {
+  const parser = createParser();
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const source = 'https://bar.example/calendar';
+
+  // Real shapes from Rockbar's widget.
+  const weekly = parser.buildEventFromElfsightRow({
+    name: 'DIRTY LITTLE SECRET',
+    start: { date: '2026-07-10', time: '20:00' },
+    end: { date: '2026-07-10', time: '21:00' },
+    timeZone: 'America/New_York',
+    repeatPeriod: 'weeklyOn',
+    repeatWeeklyOnDays: ['fr'],
+    description: '<div>Spill the tea&hellip;</div><br><div><strong>Every Friday</strong></div>'
+  }, source);
+  assert.equal(weekly.title, 'DIRTY LITTLE SECRET');
+  assert.equal(weekly.startDate.toISOString(), '2026-07-11T00:00:00.000Z', '20:00 EDT');
+  assert.equal(weekly.timezone, 'America/New_York');
+  assert.equal(weekly.recurrenceRule, 'FREQ=WEEKLY;BYDAY=FR');
+  assert.ok(!/[<>]/.test(weekly.description), 'the rich-text description is stripped to plain text');
+
+  // First Saturday of the month.
+  const monthly = parser.buildEventFromElfsightRow({
+    name: 'BEARS NIGHT OUT',
+    start: { date: '2026-05-02', time: '21:00' },
+    timeZone: 'America/New_York',
+    repeatPeriod: 'nthDayInMonth'
+  }, source);
+  assert.equal(monthly.recurrenceRule, 'FREQ=MONTHLY;BYDAY=1SA');
+
+  // Last Saturday of the month.
+  const last = parser.buildEventFromElfsightRow({
+    name: 'GORDITOS',
+    start: { date: '2026-08-29', time: '22:00' },
+    timeZone: 'America/New_York',
+    repeatPeriod: 'lastDayInMonth'
+  }, source);
+  assert.equal(last.recurrenceRule, 'FREQ=MONTHLY;BYDAY=-1SA');
+
+  // A one-off carries no rule at all, and an unmappable repeat shape is NOT guessed.
+  const once = parser.buildEventFromElfsightRow({
+    name: 'MEGA BEAR BLAST!', start: { date: '2026-09-20', time: '18:00' },
+    timeZone: 'America/New_York', repeatPeriod: 'noRepeat'
+  }, source);
+  assert.equal(once.recurrenceRule, undefined);
+  const custom = parser.buildEventFromElfsightRow({
+    name: 'ODD ONE', start: { date: '2026-09-20', time: '18:00' },
+    timeZone: 'America/New_York', repeatPeriod: 'custom'
+  }, source);
+  assert.equal(custom.recurrenceRule, undefined, 'custom repeats ship as a single dated event');
+
+  // A row with no date is not an event.
+  assert.equal(parser.buildEventFromElfsightRow({ name: 'NO DATE', start: {} }, source), null);
+});
+
+test('the Elfsight widget is read only on the configured entry page', async () => {
+  const parser = createParser();
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const parserConfig = { urls: ['https://bar.example/calendar'] };
+  let fetches = 0;
+  const httpAdapter = {
+    fetchData: async () => {
+      fetches++;
+      return { html: elfsightBootPayload([
+        { name: 'MEGA BEAR BLAST!', visible: true, start: { date: '2026-09-20', time: '18:00' }, timeZone: 'America/New_York' },
+        { name: 'HIDDEN', visible: false, start: { date: '2026-09-21', time: '18:00' } }
+      ]) };
+    }
+  };
+
+  const onEntry = await parser.collectElfsightCalendarEvents(
+    { html: ELFSIGHT_HTML, url: 'https://bar.example/calendar' }, parserConfig, httpAdapter);
+  assert.equal(onEntry.length, 1, 'invisible rows are not events');
+  assert.equal(fetches, 1);
+
+  // The same embed sits in a shared block on every other page — reading it
+  // again would republish the whole calendar per page.
+  const elsewhere = await parser.collectElfsightCalendarEvents(
+    { html: ELFSIGHT_HTML, url: 'https://bar.example/' }, parserConfig, httpAdapter);
+  assert.deepEqual(elsewhere, []);
+  assert.equal(fetches, 1, 'no second boot request');
+
+  // A trailing slash on the configured URL is still the configured URL.
+  const slashed = await parser.collectElfsightCalendarEvents(
+    { html: ELFSIGHT_HTML, url: 'https://bar.example/calendar/' },
+    { urls: ['https://bar.example/calendar'] }, httpAdapter);
+  assert.equal(slashed.length, 1);
+});
+
+test('a failed or odd-shaped Elfsight boot leaves the page unchanged', async () => {
+  const parser = createParser();
+  const parserConfig = { urls: ['https://bar.example/calendar'] };
+  const htmlData = { html: ELFSIGHT_HTML, url: 'https://bar.example/calendar' };
+  const boom = { fetchData: async () => { throw new Error('network down'); } };
+  assert.deepEqual(await parser.collectElfsightCalendarEvents(htmlData, parserConfig, boom), []);
+  const junk = { fetchData: async () => ({ html: 'not json' }) };
+  assert.deepEqual(await parser.collectElfsightCalendarEvents(htmlData, parserConfig, junk), []);
+  const empty = { fetchData: async () => ({ html: JSON.stringify({ data: {} }) }) };
+  assert.deepEqual(await parser.collectElfsightCalendarEvents(htmlData, parserConfig, empty), []);
+  // No adapter at all, and pages with no widget, are both no-ops.
+  assert.deepEqual(await parser.collectElfsightCalendarEvents(htmlData, parserConfig, null), []);
+  assert.deepEqual(await parser.collectElfsightCalendarEvents(
+    { html: '<div/>', url: 'https://bar.example/calendar' }, parserConfig, boom), []);
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -101,11 +101,17 @@ const scraperConfig = {
       // West Village leather/rock bar (185 Christopher St) with heavy bear
       // programming (Gorditos, Underbear, Bears Night Out, Rockstrap). The
       // venue's own site is the identity source: Squarespace, one page per
-      // party (/events/<slug>, each with a ?format=ical link) — but the
-      // listing's dates have been frozen since Aug 2024, so live dates come
-      // from the Thotyssey aggregator entry below and merge in here. Kink/pup
-      // nights are on the same calendar — bear check filters, not alwaysBear.
-      urls: ["https://www.rockbarnyc.com/events"],
+      // party (/events/<slug>, each with a ?format=ical link).
+      //
+      // /calendar, NOT /events. The Squarespace /events collection has been
+      // frozen since Aug 2024 (its own feed reports 0 upcoming, 7 past) and the
+      // bar moved its programming to the Elfsight calendar widget the site's
+      // nav actually links — 146 events with exact times, an IANA timezone and
+      // real recurrence, read via collectElfsightCalendarEvents. Live dates no
+      // longer depend on the Thotyssey aggregator entry below merging in.
+      // Kink/pup nights are on the same calendar — bear check filters, not
+      // alwaysBear.
+      urls: ["https://www.rockbarnyc.com/calendar"],
       alwaysBear: false,
       siteRole: "venue",
       metadata: {


### PR DESCRIPTION
Read the calendar Rockbar actually publishes, and stop a stale page dating itself forward

Rockbar looked dead. Its Squarespace /events feed reports 0 upcoming and 7 past,
all Aug 2024, and our whole contribution from that venue was ONE event —
BEARS NIGHT OUT dated 2026-08-04, which the page plainly calls
"Saturday, August 3, 2024". Owner loaded the site and saw a full season, which
is how this got caught: the bar moved its programming to /calendar (the link its
own nav uses) and that page renders client-side, so a crawl that only reads HTML
sees nothing.

1. Elfsight calendar widgets.
   /calendar embeds an Elfsight Event Calendar. The widget boots from ONE public
   GET that returns every event with exact dates and times, an IANA timezone,
   artwork and real recurrence fields — no browser, no rendering, no AI, no OCR.
   Generic by construction: the widget id comes from the page's own markup and
   the host is Elfsight's fixed service endpoint.

   - collectElfsightCalendarEvents + buildEventFromElfsightRow join JSON-LD and
     JSON-API as a third structured source. Elfsight rows skip the
     bar||address completeness gate the other two apply, because the widget IS
     the venue's own calendar on the venue's own page.
   - Recurrence maps to real RRULEs — weeklyOn -> FREQ=WEEKLY;BYDAY=…,
     nthDayInMonth -> BYDAY=1SA, lastDayInMonth -> BYDAY=-1SA — which is what
     routes those rows to ICS export and away from calendar writes. The scraper
     still never writes a series. `custom` and unrecognized shapes get NO rule
     and ship as their stated single date rather than a guessed series.
   - Read ONLY on the configured entry page. The embed sits in a shared block on
     every page of the site, and the first attempt built 150 events on /calendar
     and another 150 on the homepage before the run ran out of time merging them.
   - Config points at /calendar; the comment's note about live dates having to
     come from the Thotyssey entry is no longer true.

2. An explicitly stated year is what the PAGE says, not only what the model
   quoted. Six passes read BEARS NIGHT OUT's date; four quoted
   "Saturday, August 3, 2024" at confidence 100, but the pass that won cited
   "og:image filename: Bears-Night-Out-Aug-3.jpg" at confidence 80 — no year,
   under the explicit-year floor — so 2024 counted as a guess and the window
   repair walked a two-year-old archive forward to 2026. resolveExplicitSourceYear
   now also consults the source text, requiring the year to sit beside the value's
   own month and day with nothing but a comma and whitespace between, so a
   footer's "(c) 2024" can never pin an event.

   NOT the ISO spelling, and this is the important part. The first cut matched
   "2026-01-25" anywhere in the source and immediately cost BeefDip eight real
   events: beefdip.com shows "MONDAY JANUARY 25, 2027" while serving last year's
   flyer files from /uploads/2026/01/"2026-01-25 Welcome Party.webp". Counting
   that filename as a stated year marked eight 2027 events as archived 2026 ones
   — the exact failure this guard exists to prevent, arriving through the exact
   same door as the Rockbar bug it was written for. Only prose a reader sees
   counts. The BeefDip page is pinned as a regression test.

NOT changed: "View Event →" titles. I reported these as a defect on 3 Dollar
Bill; they are already handled. The junk-title sanity flag tags all six and
withholds them from calendar writes while deliberately keeping them visible in
results — flag, don't drop. A parser-level guard would have deleted the review
trail, so it was written and then reverted.

Full local run 20260829-120135, against the pre-wave run 20260829-110754:

  totals     455 -> 602 events, 144 -> 169 bear, 0 errors both
  Rockbar    1 -> 26 real bear events, including Mega Bear Blast (Sep 20) which
             we had never seen, plus BEARS NIGHT OUT (FREQ=MONTHLY;BYDAY=1SA)
             and GORDITOS (BYDAY=-1SA)
  Rockbar's only loss is the fabricated BEARS NIGHT OUT 2026-08-04 phantom
  BeefDip 34 -> 34, every other parser byte-identical
  massive.club drops one non-bear record whose source states an explicit 2023

Known gap, next: 24 of Rockbar's 26 events carry no bar and no address. The
structured route skips the AI extraction that used to supply them, and
applyVenueSiteIdentityCorrections builds its consensus FROM what the events say,
so a venue site whose events say nothing about the venue gets nothing — while
data/bars/nyc.json has "Rockbar · 185 Christopher St" and shares an instagram
URL with the parser's own curated metadata.
