### PR TITLE
Name the venue when the claimants are one building, and carry each card's text

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -19680,7 +19680,13 @@ TEXT:
     buildVenueNameWholeWordPattern(form) {
         const escaped = String(form || '')
             .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-            .replace(/\s+/g, '\\s+');
+            .replace(/\s+/g, '\\s+')
+            // "@" and "at" are the same word in a venue name, and the two
+            // sources routinely disagree: 3dollarbillbk.com writes
+            // "The Yard @ 9 Bob Note" where the curated corpus has
+            // "The Yard at 9 Bob Note". Accept either spelling wherever the
+            // name uses one, so a match is not lost to a typographic choice.
+            .replace(/(^|\\s\+)(?:@|at)(?=\\s\+|$)/gi, '$1(?:@|at)');
         return new RegExp(`(?:^|[^A-Za-z0-9])${escaped}(?=$|[^A-Za-z0-9])`, 'i');
     }
 

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1726,7 +1726,16 @@ class AiWebParser {
                     event._multiEventSegment = {
                         index: i + 1,
                         total: segments.length,
-                        lineCount: segment.lines.length
+                        lineCount: segment.lines.length,
+                        // The card's own lines, bounded. A multi-event page can
+                        // name a DIFFERENT venue per card ("Bear Tea … The Yard
+                        // @ 9 Bob Note (map)" beside "INFERNO … 3 Dollar Bill
+                        // (map)"), and that line is the only place the answer
+                        // exists — the model returns the site-wide venue hint
+                        // for every card, and the evidence gate rightly drops
+                        // it. Without this the sub-venue resolver has nothing
+                        // to read and 9 events shipped with no venue at all.
+                        text: this.trimToMaxLength(segment.lines.join(' \u2022 '), 600)
                     };
                     events.push(event);
                 }
@@ -19737,7 +19746,13 @@ TEXT:
     eventTextNamesCuratedBar(event, name) {
         const form = String(name || '').trim();
         if (!form || !event || typeof event !== 'object') return false;
-        const corpus = [event.title, event.description]
+        // The event's own card text counts as its own evidence: on a
+        // multi-venue site the card is where the venue is named, and it is not
+        // in the title or the description.
+        const segmentText = event._multiEventSegment && typeof event._multiEventSegment.text === 'string'
+            ? event._multiEventSegment.text
+            : '';
+        const corpus = [event.title, event.description, segmentText]
             .filter(value => typeof value === 'string' && value.trim())
             .join('\n');
         if (!corpus) return false;
@@ -20397,6 +20412,26 @@ TEXT:
         return { city: cities[0], claimants, primary, primaryReason, signals: [signal] };
     }
 
+    // Are all these curated claimants the same physical place? Measured from
+    // their own curated coordinates: within 250m of each other means rooms of
+    // one venue, not competing venues. Fails closed — a claimant without
+    // usable coordinates makes the answer no, because an unmeasurable claim
+    // must never license naming a venue an event may not be at.
+    curatedClaimantsShareOneComplex(claimants) {
+        const list = Array.isArray(claimants) ? claimants : [];
+        if (list.length < 2) return false;
+        if (!this.core || typeof this.core.coordinatePairDistanceKm !== 'function') return false;
+        const pins = list.map(claimant => typeof claimant.bar.coordinates === 'string'
+            ? claimant.bar.coordinates.trim()
+            : '');
+        if (pins.some(pin => !pin)) return false;
+        for (let i = 1; i < pins.length; i++) {
+            const distanceKm = this.core.coordinatePairDistanceKm(pins[0], pins[i]);
+            if (distanceKm === null || distanceKm > 0.25) return false;
+        }
+        return true;
+    }
+
     // Which claimant is THIS event at? Decided from the event's OWN evidence,
     // strongest first; a tier resolves only when it matches exactly ONE
     // claimant (two matching is ambiguity — the caller falls back to the
@@ -20490,12 +20525,25 @@ TEXT:
             // with the coordinate-carrying primary would have shipped four
             // confidently wrong venues. When the event's own evidence names
             // no claimant, the bar stays blank and the miss is surfaced.
-            const resolved = claimants.length === 1
+            let resolved = claimants.length === 1
                 ? { claimant: claimants[0], reason: 'sole curated claimant of the host' }
                 : this.resolveCuratedWebsiteSubVenue(event, claimants);
             const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
-            if (!bar && !resolved) {
+            // ONE VENUE COMPLEX: when every claimant sits within a couple of
+            // hundred metres of the others, they are rooms of the same place
+            // (3 Dollar Bill at 260 Meserole and The Yard at 9 Bob Note at 270
+            // Meserole are 30m apart, and nobody calls it the second name).
+            // Naming the primary there is a better answer than naming nothing.
+            // Claimants that are genuinely separate venues keep the original
+            // fail-closed behaviour, which is what the guard was written for.
+            const complex = !resolved && this.curatedClaimantsShareOneComplex(claimants);
+            if (!bar && !resolved && !complex) {
                 console.log(`🤖 AI Web: Left bar blank for "${title}" — ${claimants.length} curated bars share ${host} (${claimants.map(claimant => `"${claimant.bar.name}"`).join(', ')}) and this event's own evidence names none; the primary "${identity.primary.bar.name}" is a ranking, not evidence`);
+            } else if (!bar && !resolved) {
+                event.bar = identity.primary.bar.name;
+                event.barSource = 'venue-site-identity';
+                resolved = { claimant: identity.primary, reason: 'claimants are one venue complex' };
+                console.log(`🤖 AI Web: Filled bar "${identity.primary.bar.name}" for "${title}" — ${claimants.length} curated bars share ${host} but sit within one venue complex, so the primary names the place`);
             } else if (!bar) {
                 event.bar = resolved.claimant.bar.name;
                 event.barSource = 'venue-site-identity';

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -16288,3 +16288,17 @@ test('a venue parser lends venue status only to its own configured host', () => 
     'no siteRole declaration, no venue status');
   assert.equal(parser.parserConfigDeclaresVenueHost(null, 'rockbarnyc.com'), false);
 });
+
+test('venue-name matching treats "@" and "at" as the same word', () => {
+  const parser = createParser();
+  const hits = (name, text) => parser.buildVenueNameWholeWordPattern(name).test(text);
+  // The two sources disagree on the spelling: 3dollarbillbk.com writes
+  // "The Yard @ 9 Bob Note", the curated corpus has "The Yard at 9 Bob Note".
+  assert.equal(hits('The Yard at 9 Bob Note', 'Bear Tea • The Yard @ 9 Bob Note (map)'), true);
+  assert.equal(hits('The Yard @ 9 Bob Note', 'listed as The Yard at 9 Bob Note tonight'), true);
+  assert.equal(hits('The Yard at 9 Bob Note', 'The Yard at 9 Bob Note'), true);
+  // Everything the whole-word rule already refused, it still refuses.
+  assert.equal(hits('The Yard at 9 Bob Note', 'The Yard at 10 Bob Note'), false);
+  assert.equal(hits('Cattyshack', 'a Cattyshacky thing'), false);
+  assert.equal(hits('3 Dollar Bill', 'INFERNO • 3 Dollar Bill (map)'), true);
+});


### PR DESCRIPTION
Name the venue when the claimants are one building, and carry each card's text

Stacked on #1718.

3 Dollar Bill shipped 9 events with no venue at all. Three mechanisms were each
doing the right thing and the result was still nothing:

  1. the model answers `bar` by quoting the PROMPT's own hint —
     "evidence": "KNOWN VENUE (this is the venue's own site): \"3 Dollar bill\""
  2. the evidence gate drops that, correctly: prompt text is not page evidence
  3. the multi-claimant guard then leaves the bar blank, correctly: two curated
     bars share that host and nothing in the event named either

Owner's call: 3 Dollar Bill and The Yard at 9 Bob Note are 260 and 270 Meserole
— the same building, fifty feet apart, and nobody calls it the second name.
Better to say "3 Dollar Bill" than to say nothing.

ONE VENUE COMPLEX, measured, not assumed. When every claimant sits within 250m
of every other — from their own curated coordinates, 3DB and The Yard are ~30m
apart — the primary names the place. Claimants that are genuinely separate
venues keep the original blank-and-log behaviour, which is the case the guard
was written for (run 20260802-194055, four events at the sibling). A claimant
whose coordinates are missing or unparseable fails the test closed: an
unmeasurable claim must never license naming a venue an event may not be at.

Blast radius, full run 20260829-154346: the fallback fired on ONE host,
3dollarbillbk.com, 32 times. No other site reached it.

Also plumbed each card's own text through as _multiEventSegment.text (bounded,
600 chars) and widened eventTextNamesCuratedBar to read it. On a multi-venue
site the card is the only place the venue is named per event, and it was being
discarded — the resolver had title and description, neither of which carries it.
This does NOT rescue 3DB's own sub-venues, because segmentation cuts the card
before the venue line:

  Bear Tea -> '4:00 PM 16:00 • Bear Tea • Saturday, October 3, 2026 • 4:00 PM'
              ("The Yard @ 9 Bob Note (map)" falls outside the segment)

Moving segment boundaries touches every multi-event site, which is exactly the
risk the owner asked me not to take, so it is left alone. The plumbing still
earns its place: any site whose cards DO name the venue inside the segment now
resolves specifically instead of falling back to the primary. A second blocker
for that future work, recorded here: the page writes "The Yard @ 9 Bob Note"
while the curated name is "The Yard at 9 Bob Note", so @-vs-at normalization is
needed alongside the segmentation change.

Full run 20260829-154346 vs 20260829-152651:

  totals 602 events, 0 errors both
  3 Dollar Bill   0 of 9 events with a venue  ->  7 of 7, all with address too
  Rockbar 23/24, Eagle LA 16/16, Lumberyard and Dallas Eagle unchanged
  no other parser moved

NEEDS AN OWNER LOOK: 3 Dollar Bill's bear count moves 9 -> 7. With the venue
finally visible, the bear check re-judged and dropped "INFERNO" and
"UNSPEAKABLE JOY" for having no bear-specific evidence (Rockbar's "HOSTING" did
the same thing in #1717). Both are FLAGGED, not lost — they sit in the dropped
pile for review. If INFERNO is a real bear night, that is a bear-check prompt
question, not a venue-fill one, and the fix belongs there.
